### PR TITLE
docs: improve POS-KIOSK integration for universal same-device and cross-device support

### DIFF
--- a/pos-kiosk-integration/INTEGRATION.md
+++ b/pos-kiosk-integration/INTEGRATION.md
@@ -2,39 +2,106 @@
 
 This guide covers the integration architecture, communication protocols, and API specifications for integrating with the MobyPay Kiosk system.
 
+---
+
 ## 📋 Table of Contents
 
 - [Overview](#overview)
+- [Same Device vs Different Device](#same-device-vs-different-device)
 - [Security Architecture](#security-architecture)
 - [System Architecture](#system-architecture)
 - [Payment Methods](#payment-methods)
 - [API Documentation](#api-documentation)
-- [Message Format](#message-format)
 - [Integration Workflow](#integration-workflow)
 - [Network Configuration](#network-configuration)
+- [Platform Integration Examples](#platform-integration-examples)
+
+---
 
 ## Overview
 
 The MobyPay POS-KIOSK integration enables secure TCP-based communication between kiosk terminals and Point of Sale (POS) systems. The system supports multiple payment methods including card payments, Buy Now Pay Later (BNPL), DuitNow QR, and Installment Payment Plans (IPP).
 
+**The protocol is identical regardless of whether the Kiosk and POS are on the same physical device or on different devices connected over a network.** The only difference is the IP address used to connect:
+
+| Scenario | Kiosk IP to use |
+|---|---|
+| Same device (co-located) | `127.0.0.1` (localhost) |
+| Different devices, same LAN | Local IP, e.g. `192.168.1.100` |
+| Different devices, over internet | Public IP or hostname, e.g. `pos.merchant.com` |
+
 ### Key Features
 
-- **Secure TCP Communication**: HMAC-SHA256 message signing with nonce validation
-- **Multiple Payment Methods**: Card, BNPL, DuitNow QR, and IPP support
-- **Real-time Transaction Processing**: Instant communication between kiosk and POS
-- **Replay Attack Protection**: Nonce-based security to prevent message replay
-- **Timestamp Validation**: Time-based request validation (60-second window)
+- **Universal TCP Communication:** Works on same-device, LAN, and internet-connected deployments
+- **Cross-Platform:** Compatible with Windows, Android, iOS, Linux, and embedded POS systems
+- **Secure Messaging:** HMAC-SHA256 message signing with nonce validation
+- **Multiple Payment Methods:** Card, BNPL, DuitNow QR, and IPP support
+- **Real-time Processing:** Instant communication between Kiosk and POS
+- **Replay Attack Protection:** Nonce-based security prevents message replay
+- **Timestamp Validation:** 60-second window validation
+
+---
+
+## Same Device vs Different Device
+
+### The Golden Rule
+
+The TCP protocol and all message formats are **100% identical** whether the apps are on the same device or different devices. Only the connection target IP changes.
+
+```
+POS Client  ──────────────────────────────→  Kiosk Server (TCP listener)
+
+Same device:   connect("127.0.0.1", 8080)
+Same LAN:      connect("192.168.1.100", 8080)
+Internet:      connect("pos.merchant.com", 8080)
+```
+
+### Same Device Deployment
+
+When the MobyPay Kiosk app and the POS app run on the **same device** (Android, Windows, etc.), the POS client should connect to `127.0.0.1` (localhost) on the configured port. No network infrastructure is required.
+
+```
+Single Device
+┌──────────────────────────────────────────┐
+│  [Kiosk App]  ←── TCP ──→  [POS App]   │
+│  listens on 127.0.0.1:8080               │
+└──────────────────────────────────────────┘
+```
+
+> **Android:** Even for localhost TCP connections, the app must declare `<uses-permission android:name="android.permission.INTERNET" />` in `AndroidManifest.xml`.
+
+> **iOS:** Localhost TCP is supported via the `Network` framework. For App Store distribution, ensure background network entitlements are configured. For enterprise/kiosk deployments no additional steps are needed.
+
+### Different Device Deployment (LAN or Internet)
+
+When Kiosk and POS are on different devices, the POS connects to the Kiosk's IP address or hostname.
+
+```
+LAN:
+[POS Terminal @ 192.168.1.50]  ──→  [Kiosk @ 192.168.1.100:8080]
+
+Internet:
+[POS Terminal]  ──→  [Kiosk @ public-ip-or-hostname:8080]
+```
+
+Ensure:
+1. The Kiosk device has a **static or reserved IP** (LAN) or stable hostname/public IP (internet).
+2. **Port 8080** (or your configured port) is open and reachable from the POS device.
+3. For internet-facing deployments, **wrap the TCP connection in TLS/SSL** or use a VPN — raw TCP over the public internet is not encrypted by default.
+
+---
 
 ## 🔒 Security Architecture
 
 ### Message Signing
 
 All messages are signed using HMAC-SHA256. The signature is calculated over the payload JSON after:
-1. Sorting keys alphabetically
-2. Using compact separators (`,` for array/object elements, `:` for key-value pairs)
-3. Encoding with UTF-8
 
-**Shared Secret:** `POS-KIOSK-SECRET-KEY-2024`
+- Sorting keys alphabetically
+- Using compact separators (`,` for array/object elements, `:` for key-value pairs)
+- Encoding with UTF-8
+
+> ⚠️ **Production Security Warning:** The shared secret `POS-KIOSK-SECRET-KEY-2024` is for **development and testing only**. In production, replace it with a securely generated random string (minimum 32 characters) and distribute it to POS terminals out-of-band (never transmit it over the TCP channel itself). Rotate the key periodically.
 
 ### Nonce Validation
 
@@ -42,11 +109,14 @@ All messages are signed using HMAC-SHA256. The signature is calculated over the 
 - Each nonce can only be used once (prevents replay attacks)
 - Nonces are tracked server-side; old nonces are cleared periodically
 
+> ⚠️ **Production Note:** The default in-memory nonce store clears after 1,000 entries. For high-volume production environments, use a persistent nonce store (e.g., Redis with 60-second TTL) to prevent replay attacks under load.
+
 ### Timestamp Validation
 
 - Timestamps are in milliseconds since epoch
-- Requests must be within 60-second window from current time
+- Requests must be within a 60-second window from current time
 - Protects against time-shifted replay attacks
+- **Ensure device clocks are synchronized** via NTP on both Kiosk and POS devices
 
 ### Validation Sequence
 
@@ -55,66 +125,79 @@ All messages are signed using HMAC-SHA256. The signature is calculated over the 
 3. Validate nonce uniqueness
 4. Validate timestamp within acceptable range
 
-## System Architecture
+---
+
+## 🏗 System Architecture
 
 ```
 ┌─────────────────┐                    ┌─────────────────┐
-│   Kiosk         │ ←→ TCP (8080)  ←→  │  POS Terminal   │
-│   Server        │   (Secure)         │                 │
-│                 │                    │                 │
-│ - Listener      │                    │ - Parser        │
-│ - Sender        │                    │ - Responder     │
-│ - Handler       │                    │ - Processor     │
+│   Kiosk App     │  ←── TCP ──────→  │   POS Terminal  │
+│   (TCP Server)  │  (port 8080)       │   (TCP Client)  │
+│                 │                    │                  │
+│ - TCP Listener  │                    │ - TCP Connector  │
+│ - Msg Sender    │                    │ - Msg Parser     │
+│ - Resp Handler  │                    │ - Txn Processor  │
+│ - IPP Handler   │                    │ - Plan Provider  │
 └─────────────────┘                    └─────────────────┘
+       ▲
+       │ Connect to 127.0.0.1:8080 (same device)
+       │           OR
+       │ Connect to <kiosk-ip>:8080 (different device)
+       │
+  [POS Client]
 ```
 
 ### Component Responsibilities
 
-**Kiosk Server:**
-- Listen for incoming POS terminal connections
-- Send payment requests to connected terminals
+**Kiosk (TCP Server):**
+- Listen for incoming POS connections on configured port
+- Send payment requests to connected POS terminals
 - Receive and process transaction responses
-- Manage multiple concurrent connections
-- Handle IPP plan selection
+- Manage multiple concurrent POS connections
+- Handle IPP plan selection flow
 
-**POS Terminal Client:**
-- Connect to kiosk server
+**POS Terminal (TCP Client):**
+- Connect to Kiosk server (127.0.0.1 for same-device, or IP/hostname for remote)
 - Receive payment requests
-- Process transactions
-- Send responses with results
-- Provide IPP plans when applicable
+- Process transactions through the payment hardware/SDK
+- Send ACK and transaction result messages
+- Provide IPP plan options when applicable
+
+---
 
 ## 💳 Payment Methods
 
 ### 1. Card Payment
-- Direct card transactions through POS terminal
-- Supports credit and debit cards
-- Real-time authorization
-- Payment Mode: `card`
+Direct card transactions through the POS terminal. Supports credit and debit cards with real-time authorization.
+**Payment Mode:** `card`
 
 ### 2. Buy Now Pay Later (BNPL)
-- Installment-based payment options
-- Flexible payment terms
-- Instant approval process
-- Payment Mode: `bnpl`
+Installment-based payment options with flexible terms and instant approval.
+**Payment Mode:** `bnpl`
 
 ### 3. DuitNow QR
-- Malaysia's national QR payment system
-- Bank and e-wallet integration
-- Quick and secure transactions
-- Payment Mode: `duitnow_qr`
+Malaysia's national QR payment system supporting bank and e-wallet integration.
+**Payment Mode:** `duitnow_qr`
 
 ### 4. Installment Payment Plans (IPP)
-- Available for MobyPay BNPL account holders
-- Flexible installment payment options
-- Interactive plan selection via kiosk
-- Payment Mode: `ipp`
+Available for MobyPay BNPL account holders. Interactive plan selection via kiosk.
+**Payment Mode:** `ipp`
+
+---
 
 ## 📡 API Documentation
 
-### Message Format
+### Message Framing
 
-All messages follow this secure envelope format:
+All messages use **newline-delimited JSON**. Each message is a single JSON object followed by a newline character (`\n`). This newline is the message frame delimiter and **must always be appended** when sending.
+
+```
+<JSON object>\n
+```
+
+### Message Envelope
+
+All messages follow this secure envelope:
 
 ```json
 {
@@ -123,18 +206,19 @@ All messages follow this secure envelope format:
     "txn_id": "unique-transaction-id",
     "timestamp": "milliseconds-since-epoch",
     "nonce": "uuid-v4-string",
-    "kiosk_id": "KIOSK001",
-    ... other fields depending on message type
+    "kiosk_id": "KIOSK001"
   },
   "signature": "hmac-sha256-hex-digest"
 }
 ```
 
-### Request Types
+> The `signature` is computed over the `payload` object only — keys sorted alphabetically, compact JSON separators, UTF-8 encoded.
+
+---
+
+### Request Types (Kiosk → POS)
 
 #### 1. Transaction Request
-
-Sent by kiosk to initiate a payment transaction.
 
 ```json
 {
@@ -151,15 +235,14 @@ Sent by kiosk to initiate a payment transaction.
 }
 ```
 
-**Fields:**
-- `txn_id` (string): Unique transaction identifier (format: TXN + timestamp in milliseconds)
-- `amount` (number): Transaction amount in RM
-- `payment_mode` (string): One of `card`, `bnpl`, `duitnow_qr`, `ipp`
-- `kiosk_id` (string): Identifier of the kiosk terminal
+| Field | Type | Description |
+|---|---|---|
+| `txn_id` | string | Unique transaction ID — format: `TXN` + epoch milliseconds |
+| `amount` | number | Transaction amount in RM |
+| `payment_mode` | string | One of: `card`, `bnpl`, `duitnow_qr`, `ipp` |
+| `kiosk_id` | string | Identifier of the Kiosk terminal |
 
 #### 2. Cancel Transaction
-
-Sent by kiosk to cancel an ongoing transaction.
 
 ```json
 {
@@ -176,8 +259,6 @@ Sent by kiosk to cancel an ongoing transaction.
 
 #### 3. IPP Plan Selection
 
-Sent by kiosk to select a specific installment plan.
-
 ```json
 {
   "payload": {
@@ -192,14 +273,11 @@ Sent by kiosk to select a specific installment plan.
 }
 ```
 
-**Fields:**
-- `plan_id` (string): ID of the selected installment plan from the available plans
+---
 
-### Response Types
+### Response Types (POS → Kiosk)
 
 #### 1. Acknowledgment
-
-Sent by POS to acknowledge receipt of a request.
 
 ```json
 {
@@ -214,13 +292,12 @@ Sent by POS to acknowledge receipt of a request.
 }
 ```
 
-**Status Values:**
-- `received`: Request has been received
-- `processing`: Request is being processed
+| Status | Meaning |
+|---|---|
+| `received` | Request has been received |
+| `processing` | Request is being processed |
 
 #### 2. Transaction Result
-
-Sent by POS with the final transaction result.
 
 ```json
 {
@@ -237,13 +314,14 @@ Sent by POS with the final transaction result.
 }
 ```
 
-**Status Values:**
-- `success`: Transaction completed successfully
-- `failed`: Transaction failed
-- `approved`: Transaction approved (alternative to success)
-- `ipp_plans`: IPP plans available for selection
+| Status | Meaning |
+|---|---|
+| `success` | Transaction completed successfully |
+| `approved` | Transaction approved (alternative to success) |
+| `failed` | Transaction failed |
+| `ipp_plans` | IPP plans available — Kiosk must display and let user select |
 
-**For IPP Responses:**
+**IPP Plans Response:**
 
 ```json
 {
@@ -258,27 +336,9 @@ Sent by POS with the final transaction result.
         "frequency": "Monthly",
         "totalInstallments": 3,
         "installmentDetails": [
-          {
-            "installmentNumber": 1,
-            "date": "2024-02-15",
-            "amount": 35.00,
-            "installmentFee": 1.50,
-            "installmentFeePercentage": 1.5
-          },
-          {
-            "installmentNumber": 2,
-            "date": "2024-03-15",
-            "amount": 35.00,
-            "installmentFee": 1.50,
-            "installmentFeePercentage": 1.5
-          },
-          {
-            "installmentNumber": 3,
-            "date": "2024-04-15",
-            "amount": 35.00,
-            "installmentFee": 1.50,
-            "installmentFeePercentage": 1.5
-          }
+          { "installmentNumber": 1, "date": "2024-02-15", "amount": 35.00, "installmentFee": 1.50, "installmentFeePercentage": 1.5 },
+          { "installmentNumber": 2, "date": "2024-03-15", "amount": 35.00, "installmentFee": 1.50, "installmentFeePercentage": 1.5 },
+          { "installmentNumber": 3, "date": "2024-04-15", "amount": 35.00, "installmentFee": 1.50, "installmentFeePercentage": 1.5 }
         ]
       }
     ],
@@ -290,8 +350,6 @@ Sent by POS with the final transaction result.
 ```
 
 #### 3. Error Response
-
-Sent by POS when an error occurs.
 
 ```json
 {
@@ -306,105 +364,384 @@ Sent by POS when an error occurs.
 }
 ```
 
-## Integration Workflow
+---
+
+## 🔄 Integration Workflow
 
 ### Standard Payment Flow
 
 ```
-Kiosk                           POS Terminal
-  │                               │
-  ├─── Transaction Request ──────→│
-  │                               │
-  │←─── Acknowledgment (ACK) ─────┤
-  │                               │
-  │       [Processing]            │
-  │                               │
-  │←─Transaction Result (Success)─│
-  │                               │
-  └─── Display Result ───────────→│
+Kiosk (Server)                    POS Terminal (Client)
+     │                                     │
+     │◄──────────── TCP Connect ───────────│
+     │                                     │
+     ├──────── Transaction Request ───────►│
+     │                                     │
+     │◄───────── Acknowledgment (ACK) ─────│
+     │                                     │
+     │         [POS processes payment]      │
+     │                                     │
+     │◄───── Transaction Result ───────────│
+     │                                     │
+     ├──────── Display Result ────────────►│
 ```
 
 ### IPP Payment Flow
 
 ```
-Kiosk                           POS Terminal
-  │                               │
-  ├─── Transaction Request (IPP)─→│
-  │                               │
-  │←─── Acknowledgment (ACK) ─────┤
-  │                               │
-  │       [Processing]            │
-  │                               │
-  │←─ Transaction Result (Plans)──│
-  │                               │
-  ├─ Display IPP Plans ──────────→│
-  │ (User selects plan)           │
-  │                               │
-  ├─── Plan Selection ───────────→│
-  │                               │
-  │←─── Acknowledgment (ACK) ─────┤
-  │                               │
-  │       [Processing]            │
-  │                               │
-  │←─Transaction Result (Success)─│
-  │                               │
-  └─── Display Result ───────────→│
+Kiosk (Server)                    POS Terminal (Client)
+     │                                     │
+     ├──── Transaction Request (IPP) ─────►│
+     │◄──── Acknowledgment (ACK) ──────────│
+     │◄──── Transaction Result (ipp_plans)─│
+     ├──── Display Plans to User ─────────►│
+     │      (User selects plan)             │
+     ├──── IPP Plan Selection ────────────►│
+     │◄──── Acknowledgment (ACK) ──────────│
+     │◄──── Transaction Result (success) ──│
+     ├──── Display Result ────────────────►│
 ```
 
 ### Error Handling Flow
 
 ```
-Kiosk                           POS Terminal
-  │                               │
-  ├─── Transaction Request ──────→│
-  │                               │
-  │←─── Error Response ───────────│
-  │                               │
-  └─── Display Error ────────────→│
+Kiosk (Server)                    POS Terminal (Client)
+     │                                     │
+     ├──── Transaction Request ───────────►│
+     │◄──── Error Response ────────────────│
+     ├──── Display Error ─────────────────►│
 ```
 
-### Transaction Cancellation Flow
+### Connection Lifecycle & Reconnection
 
-```
-Kiosk                           POS Terminal
-  │                               │
-  ├─ Cancel Transaction Request ──│
-  │                               │
-  │←─── Acknowledgment (ACK) ─────┤
-  │                               │
-  └─── Transaction Cancelled ────→│
-```
+The POS terminal (client) is responsible for maintaining the connection:
 
-## Network Configuration
-
-### Requirements
-
-- Network connectivity between kiosk and POS terminals
-- Open TCP port for communication (default: 8080)
-- Shared secret key for message authentication
-- Synchronized clocks (within 60-second tolerance)
-
-### Local Network Setup
-
-- System operates within local network environment
-- Kiosk and POS terminals must be on the same network
-- Use local IP addresses (e.g., 192.168.1.x)
-- Default port 8080 should be accessible within local network
-
-### Connection Validation
-
-- Secure client-server handshake on connection establishment
-- Message signature validation on all communications
-- Automatic cleanup of inactive connections
-- Support for multiple concurrent POS terminal connections
-
-### Recommended Configuration
-
-- **Kiosk IP**: Static local IP address (e.g., 192.168.1.100)
-- **Port**: 8080 (customizable during startup)
-- **Timeout**: 60-second window for message timestamp validation
-- **Nonce Storage**: In-memory with periodic cleanup after 1000 entries
+1. **On startup:** Connect to the Kiosk server (127.0.0.1 for same device, or Kiosk IP for remote).
+2. **Keep-alive (recommended):** Send a lightweight ping message every 30 seconds to detect stale connections early.
+3. **On disconnect:** Implement exponential backoff retry — e.g., 1s → 2s → 4s → 8s, up to a max of 30s between retries.
+4. **Mid-transaction disconnect:** If the connection drops during a transaction, the POS should attempt reconnect and send an `error` result for the in-flight `txn_id` once reconnected, so the Kiosk can reset its state.
+5. **Kiosk side:** Clean up socket state when a client disconnects; allow reconnection cleanly without requiring a server restart.
 
 ---
 
-**Note:** For implementation examples and testing procedures, refer to `TESTING.md`
+## 🌐 Network Configuration
+
+### Requirements
+
+- TCP connectivity between Kiosk and POS (same device, LAN, or internet)
+- Open TCP port (default: **8080**)
+- Shared HMAC secret on both sides
+- Synchronized device clocks (within 60-second tolerance — use NTP)
+
+### Deployment Scenarios
+
+| Scenario | Kiosk IP | Notes |
+|---|---|---|
+| Same device | `127.0.0.1` | Android requires INTERNET permission |
+| Same LAN | e.g. `192.168.1.100` | Reserve IP via DHCP or set static assignment |
+| Internet | Public IP or hostname | Use TLS tunnel or VPN; open port in firewall |
+
+### Android Network Security
+
+For Android apps targeting API 28+, if connecting over cleartext TCP (non-TLS), add a network security config:
+
+```xml
+<!-- res/xml/network_security_config.xml -->
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">192.168.1.100</domain>
+  </domain-config>
+</network-security-config>
+```
+
+Reference it in your `AndroidManifest.xml`:
+```xml
+<application
+  android:networkSecurityConfig="@xml/network_security_config"
+  ...>
+```
+
+> For same-device (127.0.0.1) connections, cleartext is acceptable. For internet deployments, use TLS.
+
+### iOS Network Configuration
+
+iOS apps using the `Network` framework for TCP connections may need:
+- `NSLocalNetworkUsageDescription` in `Info.plist` for LAN discovery
+- Bonjour services declaration for same-network browsing (if using mDNS for discovery)
+- For enterprise/kiosk deployments (not App Store), no additional restrictions apply
+
+### Production Configuration
+
+| Parameter | Recommended Value |
+|---|---|
+| Port | 8080 (or any port > 1024) |
+| Shared secret | Randomly generated, minimum 32 characters |
+| Timestamp tolerance | 60 seconds |
+| Nonce store | Redis with 60s TTL (production); in-memory (development) |
+| Clock sync | NTP enabled on all devices |
+| TLS | Required for internet-facing deployments |
+
+---
+
+## 💻 Platform Integration Examples
+
+The core TCP protocol is identical on all platforms. Only the socket API differs.
+
+### Android (Kotlin)
+
+```kotlin
+import java.net.Socket
+import java.io.*
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import org.json.JSONObject
+import java.util.UUID
+
+class KioskTcpClient(
+    private val kioskHost: String,  // "127.0.0.1" (same device) or IP/hostname (remote)
+    private val kioskPort: Int = 8080,
+    private val secret: String = "YOUR-PRODUCTION-SECRET-KEY",
+    private val kioskId: String = "KIOSK001"
+) {
+    private var socket: Socket? = null
+    private var writer: PrintWriter? = null
+    private var reader: BufferedReader? = null
+
+    fun connect() {
+        socket = Socket(kioskHost, kioskPort)
+        writer = PrintWriter(socket!!.getOutputStream(), true)
+        reader = BufferedReader(InputStreamReader(socket!!.getInputStream()))
+    }
+
+    fun sendPayment(txnId: String, amount: Double, paymentMode: String): String {
+        val payload = JSONObject().apply {
+            put("type", "transaction_request")
+            put("txn_id", txnId)
+            put("amount", amount)
+            put("payment_mode", paymentMode)
+            put("kiosk_id", kioskId)
+            put("timestamp", System.currentTimeMillis().toString())
+            put("nonce", UUID.randomUUID().toString())
+        }
+        val message = buildSignedMessage(payload)
+        writer?.println(message)           // println appends \n (the required frame delimiter)
+        return reader?.readLine() ?: ""    // readLine reads until \n
+    }
+
+    private fun sign(payload: JSONObject): String {
+        // Build canonical JSON: keys sorted, compact separators
+        val sorted = payload.keys().asSequence().sorted()
+            .joinToString(",", "{", "}") { key ->
+                val v = payload.get(key)
+                val valStr = when (v) {
+                    is String -> "\"$v\""
+                    is Boolean -> v.toString()
+                    else -> v.toString()
+                }
+                "\"$key\":$valStr"
+            }
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+        return mac.doFinal(sorted.toByteArray(Charsets.UTF_8)).joinToString("") { "%02x".format(it) }
+    }
+
+    private fun buildSignedMessage(payload: JSONObject): String {
+        val envelope = JSONObject()
+        envelope.put("payload", payload)
+        envelope.put("signature", sign(payload))
+        return envelope.toString()
+    }
+
+    fun disconnect() { socket?.close() }
+}
+
+// Usage — same code works for same-device and remote
+fun example() {
+    // Same device
+    val client = KioskTcpClient(kioskHost = "127.0.0.1")
+    // Different device on LAN
+    // val client = KioskTcpClient(kioskHost = "192.168.1.100")
+    // Over internet
+    // val client = KioskTcpClient(kioskHost = "pos.merchant.com")
+
+    client.connect()
+    val txnId = "TXN${System.currentTimeMillis()}"
+    val response = client.sendPayment(txnId, 50.0, "card")
+    println("POS response: $response")
+    client.disconnect()
+}
+```
+
+### iOS / Swift
+
+```swift
+import Network
+import Foundation
+import CryptoKit
+
+class KioskTcpClient {
+    private var connection: NWConnection?
+    private let kioskHost: String    // "127.0.0.1" (same device) or IP/hostname (remote)
+    private let kioskPort: UInt16
+    private let secret: String
+    private let kioskId: String
+
+    init(host: String = "127.0.0.1", port: UInt16 = 8080,
+         secret: String = "YOUR-PRODUCTION-SECRET-KEY",
+         kioskId: String = "KIOSK001") {
+        self.kioskHost = host
+        self.kioskPort = port
+        self.secret = secret
+        self.kioskId = kioskId
+    }
+
+    func connect(onReady: @escaping () -> Void) {
+        let endpoint = NWEndpoint.hostPort(
+            host: NWEndpoint.Host(kioskHost),
+            port: NWEndpoint.Port(rawValue: kioskPort)!
+        )
+        connection = NWConnection(to: endpoint, using: .tcp)
+        connection?.stateUpdateHandler = { [weak self] state in
+            if case .ready = state { onReady() }
+        }
+        connection?.start(queue: .global())
+    }
+
+    func sendPayment(txnId: String, amount: Double, paymentMode: String) {
+        var payload: [String: Any] = [
+            "type": "transaction_request",
+            "txn_id": txnId,
+            "amount": amount,
+            "payment_mode": paymentMode,
+            "kiosk_id": kioskId,
+            "timestamp": String(Int(Date().timeIntervalSince1970 * 1000)),
+            "nonce": UUID().uuidString
+        ]
+        let signature = sign(payload: payload)
+        let envelope: [String: Any] = ["payload": payload, "signature": signature]
+        if var data = try? JSONSerialization.data(withJSONObject: envelope) {
+            data.append(contentsOf: "\n".utf8)   // append newline frame delimiter
+            connection?.send(content: data, completion: .idempotent)
+        }
+    }
+
+    private func sign(payload: [String: Any]) -> String {
+        let sorted = payload.keys.sorted().map { key -> String in
+            let val = payload[key]!
+            let valStr: String
+            switch val {
+            case let s as String: valStr = "\"\(s)\""
+            case let b as Bool: valStr = b ? "true" : "false"
+            default: valStr = "\(val)"
+            }
+            return "\"\(key)\":\(valStr)"
+        }.joined(separator: ",")
+        let json = "{\(sorted)}"
+        let key = SymmetricKey(data: Data(secret.utf8))
+        let sig = HMAC<SHA256>.authenticationCode(for: Data(json.utf8), using: key)
+        return sig.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// Usage — same code, just change the host
+// Same device:     KioskTcpClient(host: "127.0.0.1")
+// LAN:             KioskTcpClient(host: "192.168.1.100")
+// Internet:        KioskTcpClient(host: "pos.merchant.com")
+```
+
+### Windows / C# (.NET)
+
+```csharp
+using System;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using System.Security.Cryptography;
+using System.Collections.Generic;
+using System.IO;
+
+public class KioskTcpClient : IDisposable
+{
+    private TcpClient? _client;
+    private StreamReader? _reader;
+    private StreamWriter? _writer;
+
+    private readonly string _kioskHost;  // "127.0.0.1" (same device) or IP/hostname (remote)
+    private readonly int _kioskPort;
+    private readonly string _secret;
+    private readonly string _kioskId;
+
+    public KioskTcpClient(string host = "127.0.0.1", int port = 8080,
+                          string secret = "YOUR-PRODUCTION-SECRET-KEY",
+                          string kioskId = "KIOSK001")
+    {
+        _kioskHost = host;
+        _kioskPort = port;
+        _secret = secret;
+        _kioskId = kioskId;
+    }
+
+    public void Connect()
+    {
+        _client = new TcpClient(_kioskHost, _kioskPort);
+        var stream = _client.GetStream();
+        _reader = new StreamReader(stream);
+        _writer = new StreamWriter(stream) { AutoFlush = true };
+    }
+
+    public string SendPayment(string txnId, double amount, string paymentMode)
+    {
+        var payload = new Dictionary<string, object>
+        {
+            ["type"] = "transaction_request",
+            ["txn_id"] = txnId,
+            ["amount"] = amount,
+            ["payment_mode"] = paymentMode,
+            ["kiosk_id"] = _kioskId,
+            ["timestamp"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(),
+            ["nonce"] = Guid.NewGuid().ToString()
+        };
+        var signature = Sign(payload);
+        var envelope = new { payload, signature };
+        var json = JsonSerializer.Serialize(envelope);
+        _writer!.WriteLine(json);          // WriteLine appends \n (the required frame delimiter)
+        return _reader!.ReadLine() ?? "";  // ReadLine reads until \n
+    }
+
+    private string Sign(Dictionary<string, object> payload)
+    {
+        var sorted = new SortedDictionary<string, object>(payload);
+        var json = JsonSerializer.Serialize(sorted, new JsonSerializerOptions { WriteIndented = false });
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(_secret));
+        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(json));
+        return BitConverter.ToString(hash).Replace("-", "").ToLower();
+    }
+
+    public void Dispose() { _client?.Dispose(); }
+}
+
+// Usage — same code, just change the host:
+// Same device:   new KioskTcpClient(host: "127.0.0.1")
+// LAN:           new KioskTcpClient(host: "192.168.1.100")
+// Internet:      new KioskTcpClient(host: "pos.merchant.com")
+
+class Program
+{
+    static void Main()
+    {
+        using var client = new KioskTcpClient(host: "127.0.0.1");
+        client.Connect();
+        var txnId = $"TXN{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
+        var response = client.SendPayment(txnId, 50.0, "card");
+        Console.WriteLine($"POS response: {response}");
+    }
+}
+```
+
+### Python (Reference / Testing)
+
+See `kiosk.py` in this repository for the full reference server implementation, and `TESTING.md` for a minimal Python POS client example.
+
+---
+
+*For installation, testing procedures, and troubleshooting, refer to [TESTING.md](TESTING.md)*

--- a/pos-kiosk-integration/INTEGRATION.md
+++ b/pos-kiosk-integration/INTEGRATION.md
@@ -1,6 +1,8 @@
-# MobyPay POS-KIOSK Integration Guide
+# MobyPay POS-KIOSK Integration — API Reference
 
-This guide covers the integration architecture, communication protocols, and API specifications for integrating with the MobyPay Kiosk system.
+> 🚀 **New to this integration?** Start with **[QUICKSTART.md](QUICKSTART.md)** — get a working POS connection on any platform in under 5 minutes, with full copy-paste code for Android, iOS, and Windows.
+>
+> This document is the **complete API reference** covering all message formats, security model, and architecture details.
 
 ---
 
@@ -14,7 +16,6 @@ This guide covers the integration architecture, communication protocols, and API
 - [API Documentation](#api-documentation)
 - [Integration Workflow](#integration-workflow)
 - [Network Configuration](#network-configuration)
-- [Platform Integration Examples](#platform-integration-examples)
 
 ---
 
@@ -143,8 +144,6 @@ All messages are signed using HMAC-SHA256. The signature is calculated over the 
        │ Connect to 127.0.0.1:8080 (same device)
        │           OR
        │ Connect to <kiosk-ip>:8080 (different device)
-       │
-  [POS Client]
 ```
 
 ### Component Responsibilities
@@ -167,21 +166,12 @@ All messages are signed using HMAC-SHA256. The signature is calculated over the 
 
 ## 💳 Payment Methods
 
-### 1. Card Payment
-Direct card transactions through the POS terminal. Supports credit and debit cards with real-time authorization.
-**Payment Mode:** `card`
-
-### 2. Buy Now Pay Later (BNPL)
-Installment-based payment options with flexible terms and instant approval.
-**Payment Mode:** `bnpl`
-
-### 3. DuitNow QR
-Malaysia's national QR payment system supporting bank and e-wallet integration.
-**Payment Mode:** `duitnow_qr`
-
-### 4. Installment Payment Plans (IPP)
-Available for MobyPay BNPL account holders. Interactive plan selection via kiosk.
-**Payment Mode:** `ipp`
+| Payment Mode | Description |
+|---|---|
+| `card` | Direct card-present transaction — credit and debit with real-time authorization |
+| `bnpl` | Buy Now Pay Later — installment-based, flexible terms, instant approval |
+| `duitnow_qr` | DuitNow QR — Malaysia national QR payment, bank and e-wallet integration |
+| `ipp` | Installment Payment Plans — available for MobyPay BNPL holders, interactive plan selection |
 
 ---
 
@@ -189,7 +179,7 @@ Available for MobyPay BNPL account holders. Interactive plan selection via kiosk
 
 ### Message Framing
 
-All messages use **newline-delimited JSON**. Each message is a single JSON object followed by a newline character (`\n`). This newline is the message frame delimiter and **must always be appended** when sending.
+All messages use **newline-delimited JSON**. Each message is a single JSON object followed by a newline character (`\n`). This newline is the message frame delimiter and **must always be appended** when sending, and read with a `readLine()`-style call on the receiver.
 
 ```
 <JSON object>\n
@@ -197,7 +187,7 @@ All messages use **newline-delimited JSON**. Each message is a single JSON objec
 
 ### Message Envelope
 
-All messages follow this secure envelope:
+All messages (both directions) use this signed envelope structure:
 
 ```json
 {
@@ -212,13 +202,15 @@ All messages follow this secure envelope:
 }
 ```
 
-> The `signature` is computed over the `payload` object only — keys sorted alphabetically, compact JSON separators, UTF-8 encoded.
+> The `signature` is computed over the `payload` object only — keys sorted alphabetically, compact separators (`,` and `:`), UTF-8 encoded. See [QUICKSTART.md](QUICKSTART.md) for per-platform signing code.
 
 ---
 
 ### Request Types (Kiosk → POS)
 
 #### 1. Transaction Request
+
+Initiates a payment. Sent by the Kiosk when the operator triggers a payment.
 
 ```json
 {
@@ -241,8 +233,12 @@ All messages follow this secure envelope:
 | `amount` | number | Transaction amount in RM |
 | `payment_mode` | string | One of: `card`, `bnpl`, `duitnow_qr`, `ipp` |
 | `kiosk_id` | string | Identifier of the Kiosk terminal |
+| `timestamp` | string | Milliseconds since epoch (string) |
+| `nonce` | string | UUID v4, unique per message |
 
 #### 2. Cancel Transaction
+
+Cancels an in-progress transaction. POS must ACK and abort any in-flight hardware operation.
 
 ```json
 {
@@ -258,6 +254,8 @@ All messages follow this secure envelope:
 ```
 
 #### 3. IPP Plan Selection
+
+Sent by Kiosk after the user selects an installment plan from the options provided by the POS.
 
 ```json
 {
@@ -277,7 +275,9 @@ All messages follow this secure envelope:
 
 ### Response Types (POS → Kiosk)
 
-#### 1. Acknowledgment
+#### 1. Acknowledgment (ACK)
+
+Sent immediately by POS upon receiving any request. Confirms receipt before processing begins.
 
 ```json
 {
@@ -292,12 +292,14 @@ All messages follow this secure envelope:
 }
 ```
 
-| Status | Meaning |
+| `status` | Meaning |
 |---|---|
 | `received` | Request has been received |
 | `processing` | Request is being processed |
 
 #### 2. Transaction Result
+
+Final outcome of the transaction. Sent by POS after the payment hardware/SDK responds.
 
 ```json
 {
@@ -314,12 +316,20 @@ All messages follow this secure envelope:
 }
 ```
 
-| Status | Meaning |
+| `status` | Meaning |
 |---|---|
 | `success` | Transaction completed successfully |
 | `approved` | Transaction approved (alternative to success) |
 | `failed` | Transaction failed |
-| `ipp_plans` | IPP plans available — Kiosk must display and let user select |
+| `ipp_plans` | IPP plans available — Kiosk will display them for user selection |
+
+**Optional result fields by payment mode:**
+
+| Field | Present when | Description |
+|---|---|---|
+| `authorization_code` | Card / BNPL success | Auth code from payment network |
+| `card_last4` | Card success | Last 4 digits of card number |
+| `plans` | status = `ipp_plans` | Array of installment plan objects (see IPP below) |
 
 **IPP Plans Response:**
 
@@ -351,6 +361,8 @@ All messages follow this secure envelope:
 
 #### 3. Error Response
 
+Sent when the POS cannot process the request (hardware error, configuration issue, etc.).
+
 ```json
 {
   "payload": {
@@ -376,13 +388,9 @@ Kiosk (Server)                    POS Terminal (Client)
      │◄──────────── TCP Connect ───────────│
      │                                     │
      ├──────── Transaction Request ───────►│
-     │                                     │
-     │◄───────── Acknowledgment (ACK) ─────│
-     │                                     │
+     │◄───────── ACK (processing) ─────────│
      │         [POS processes payment]      │
-     │                                     │
      │◄───── Transaction Result ───────────│
-     │                                     │
      ├──────── Display Result ────────────►│
 ```
 
@@ -392,35 +400,35 @@ Kiosk (Server)                    POS Terminal (Client)
 Kiosk (Server)                    POS Terminal (Client)
      │                                     │
      ├──── Transaction Request (IPP) ─────►│
-     │◄──── Acknowledgment (ACK) ──────────│
+     │◄──── ACK (processing) ──────────────│
      │◄──── Transaction Result (ipp_plans)─│
      ├──── Display Plans to User ─────────►│
      │      (User selects plan)             │
      ├──── IPP Plan Selection ────────────►│
-     │◄──── Acknowledgment (ACK) ──────────│
+     │◄──── ACK (processing) ──────────────│
      │◄──── Transaction Result (success) ──│
      ├──── Display Result ────────────────►│
 ```
 
-### Error Handling Flow
+### Cancellation Flow
 
 ```
 Kiosk (Server)                    POS Terminal (Client)
      │                                     │
-     ├──── Transaction Request ───────────►│
-     │◄──── Error Response ────────────────│
-     ├──── Display Error ─────────────────►│
+     ├──── Cancel Transaction ────────────►│
+     │◄──── ACK (received) ────────────────│
+     │      [POS aborts hardware txn]       │
 ```
 
 ### Connection Lifecycle & Reconnection
 
 The POS terminal (client) is responsible for maintaining the connection:
 
-1. **On startup:** Connect to the Kiosk server (127.0.0.1 for same device, or Kiosk IP for remote).
-2. **Keep-alive (recommended):** Send a lightweight ping message every 30 seconds to detect stale connections early.
+1. **On startup:** Connect to the Kiosk server (`127.0.0.1` for same device, or Kiosk IP for remote).
+2. **Keep-alive (recommended):** Detect stale connections by monitoring read timeouts or sending a lightweight ping every 30 seconds.
 3. **On disconnect:** Implement exponential backoff retry — e.g., 1s → 2s → 4s → 8s, up to a max of 30s between retries.
-4. **Mid-transaction disconnect:** If the connection drops during a transaction, the POS should attempt reconnect and send an `error` result for the in-flight `txn_id` once reconnected, so the Kiosk can reset its state.
-5. **Kiosk side:** Clean up socket state when a client disconnects; allow reconnection cleanly without requiring a server restart.
+4. **Mid-transaction disconnect:** Send an `error` result for the in-flight `txn_id` once reconnected, so the Kiosk can reset its state.
+5. **Kiosk side:** Clean up socket state when a client disconnects; allow reconnection without requiring a server restart.
 
 ---
 
@@ -441,9 +449,9 @@ The POS terminal (client) is responsible for maintaining the connection:
 | Same LAN | e.g. `192.168.1.100` | Reserve IP via DHCP or set static assignment |
 | Internet | Public IP or hostname | Use TLS tunnel or VPN; open port in firewall |
 
-### Android Network Security
+### Android Network Security {#android-network-security}
 
-For Android apps targeting API 28+, if connecting over cleartext TCP (non-TLS), add a network security config:
+For Android apps targeting API 28+, add a network security config to allow cleartext TCP to the Kiosk IP:
 
 ```xml
 <!-- res/xml/network_security_config.xml -->
@@ -454,20 +462,18 @@ For Android apps targeting API 28+, if connecting over cleartext TCP (non-TLS), 
 </network-security-config>
 ```
 
-Reference it in your `AndroidManifest.xml`:
+Reference it in `AndroidManifest.xml`:
+
 ```xml
-<application
-  android:networkSecurityConfig="@xml/network_security_config"
-  ...>
+<application android:networkSecurityConfig="@xml/network_security_config" ...>
 ```
 
-> For same-device (127.0.0.1) connections, cleartext is acceptable. For internet deployments, use TLS.
+> For same-device (`127.0.0.1`) connections, cleartext is acceptable. For internet deployments, use TLS.
 
 ### iOS Network Configuration
 
 iOS apps using the `Network` framework for TCP connections may need:
 - `NSLocalNetworkUsageDescription` in `Info.plist` for LAN discovery
-- Bonjour services declaration for same-network browsing (if using mDNS for discovery)
 - For enterprise/kiosk deployments (not App Store), no additional restrictions apply
 
 ### Production Configuration
@@ -483,265 +489,5 @@ iOS apps using the `Network` framework for TCP connections may need:
 
 ---
 
-## 💻 Platform Integration Examples
-
-The core TCP protocol is identical on all platforms. Only the socket API differs.
-
-### Android (Kotlin)
-
-```kotlin
-import java.net.Socket
-import java.io.*
-import javax.crypto.Mac
-import javax.crypto.spec.SecretKeySpec
-import org.json.JSONObject
-import java.util.UUID
-
-class KioskTcpClient(
-    private val kioskHost: String,  // "127.0.0.1" (same device) or IP/hostname (remote)
-    private val kioskPort: Int = 8080,
-    private val secret: String = "YOUR-PRODUCTION-SECRET-KEY",
-    private val kioskId: String = "KIOSK001"
-) {
-    private var socket: Socket? = null
-    private var writer: PrintWriter? = null
-    private var reader: BufferedReader? = null
-
-    fun connect() {
-        socket = Socket(kioskHost, kioskPort)
-        writer = PrintWriter(socket!!.getOutputStream(), true)
-        reader = BufferedReader(InputStreamReader(socket!!.getInputStream()))
-    }
-
-    fun sendPayment(txnId: String, amount: Double, paymentMode: String): String {
-        val payload = JSONObject().apply {
-            put("type", "transaction_request")
-            put("txn_id", txnId)
-            put("amount", amount)
-            put("payment_mode", paymentMode)
-            put("kiosk_id", kioskId)
-            put("timestamp", System.currentTimeMillis().toString())
-            put("nonce", UUID.randomUUID().toString())
-        }
-        val message = buildSignedMessage(payload)
-        writer?.println(message)           // println appends \n (the required frame delimiter)
-        return reader?.readLine() ?: ""    // readLine reads until \n
-    }
-
-    private fun sign(payload: JSONObject): String {
-        // Build canonical JSON: keys sorted, compact separators
-        val sorted = payload.keys().asSequence().sorted()
-            .joinToString(",", "{", "}") { key ->
-                val v = payload.get(key)
-                val valStr = when (v) {
-                    is String -> "\"$v\""
-                    is Boolean -> v.toString()
-                    else -> v.toString()
-                }
-                "\"$key\":$valStr"
-            }
-        val mac = Mac.getInstance("HmacSHA256")
-        mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
-        return mac.doFinal(sorted.toByteArray(Charsets.UTF_8)).joinToString("") { "%02x".format(it) }
-    }
-
-    private fun buildSignedMessage(payload: JSONObject): String {
-        val envelope = JSONObject()
-        envelope.put("payload", payload)
-        envelope.put("signature", sign(payload))
-        return envelope.toString()
-    }
-
-    fun disconnect() { socket?.close() }
-}
-
-// Usage — same code works for same-device and remote
-fun example() {
-    // Same device
-    val client = KioskTcpClient(kioskHost = "127.0.0.1")
-    // Different device on LAN
-    // val client = KioskTcpClient(kioskHost = "192.168.1.100")
-    // Over internet
-    // val client = KioskTcpClient(kioskHost = "pos.merchant.com")
-
-    client.connect()
-    val txnId = "TXN${System.currentTimeMillis()}"
-    val response = client.sendPayment(txnId, 50.0, "card")
-    println("POS response: $response")
-    client.disconnect()
-}
-```
-
-### iOS / Swift
-
-```swift
-import Network
-import Foundation
-import CryptoKit
-
-class KioskTcpClient {
-    private var connection: NWConnection?
-    private let kioskHost: String    // "127.0.0.1" (same device) or IP/hostname (remote)
-    private let kioskPort: UInt16
-    private let secret: String
-    private let kioskId: String
-
-    init(host: String = "127.0.0.1", port: UInt16 = 8080,
-         secret: String = "YOUR-PRODUCTION-SECRET-KEY",
-         kioskId: String = "KIOSK001") {
-        self.kioskHost = host
-        self.kioskPort = port
-        self.secret = secret
-        self.kioskId = kioskId
-    }
-
-    func connect(onReady: @escaping () -> Void) {
-        let endpoint = NWEndpoint.hostPort(
-            host: NWEndpoint.Host(kioskHost),
-            port: NWEndpoint.Port(rawValue: kioskPort)!
-        )
-        connection = NWConnection(to: endpoint, using: .tcp)
-        connection?.stateUpdateHandler = { [weak self] state in
-            if case .ready = state { onReady() }
-        }
-        connection?.start(queue: .global())
-    }
-
-    func sendPayment(txnId: String, amount: Double, paymentMode: String) {
-        var payload: [String: Any] = [
-            "type": "transaction_request",
-            "txn_id": txnId,
-            "amount": amount,
-            "payment_mode": paymentMode,
-            "kiosk_id": kioskId,
-            "timestamp": String(Int(Date().timeIntervalSince1970 * 1000)),
-            "nonce": UUID().uuidString
-        ]
-        let signature = sign(payload: payload)
-        let envelope: [String: Any] = ["payload": payload, "signature": signature]
-        if var data = try? JSONSerialization.data(withJSONObject: envelope) {
-            data.append(contentsOf: "\n".utf8)   // append newline frame delimiter
-            connection?.send(content: data, completion: .idempotent)
-        }
-    }
-
-    private func sign(payload: [String: Any]) -> String {
-        let sorted = payload.keys.sorted().map { key -> String in
-            let val = payload[key]!
-            let valStr: String
-            switch val {
-            case let s as String: valStr = "\"\(s)\""
-            case let b as Bool: valStr = b ? "true" : "false"
-            default: valStr = "\(val)"
-            }
-            return "\"\(key)\":\(valStr)"
-        }.joined(separator: ",")
-        let json = "{\(sorted)}"
-        let key = SymmetricKey(data: Data(secret.utf8))
-        let sig = HMAC<SHA256>.authenticationCode(for: Data(json.utf8), using: key)
-        return sig.map { String(format: "%02x", $0) }.joined()
-    }
-}
-
-// Usage — same code, just change the host
-// Same device:     KioskTcpClient(host: "127.0.0.1")
-// LAN:             KioskTcpClient(host: "192.168.1.100")
-// Internet:        KioskTcpClient(host: "pos.merchant.com")
-```
-
-### Windows / C# (.NET)
-
-```csharp
-using System;
-using System.Net.Sockets;
-using System.Text;
-using System.Text.Json;
-using System.Security.Cryptography;
-using System.Collections.Generic;
-using System.IO;
-
-public class KioskTcpClient : IDisposable
-{
-    private TcpClient? _client;
-    private StreamReader? _reader;
-    private StreamWriter? _writer;
-
-    private readonly string _kioskHost;  // "127.0.0.1" (same device) or IP/hostname (remote)
-    private readonly int _kioskPort;
-    private readonly string _secret;
-    private readonly string _kioskId;
-
-    public KioskTcpClient(string host = "127.0.0.1", int port = 8080,
-                          string secret = "YOUR-PRODUCTION-SECRET-KEY",
-                          string kioskId = "KIOSK001")
-    {
-        _kioskHost = host;
-        _kioskPort = port;
-        _secret = secret;
-        _kioskId = kioskId;
-    }
-
-    public void Connect()
-    {
-        _client = new TcpClient(_kioskHost, _kioskPort);
-        var stream = _client.GetStream();
-        _reader = new StreamReader(stream);
-        _writer = new StreamWriter(stream) { AutoFlush = true };
-    }
-
-    public string SendPayment(string txnId, double amount, string paymentMode)
-    {
-        var payload = new Dictionary<string, object>
-        {
-            ["type"] = "transaction_request",
-            ["txn_id"] = txnId,
-            ["amount"] = amount,
-            ["payment_mode"] = paymentMode,
-            ["kiosk_id"] = _kioskId,
-            ["timestamp"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(),
-            ["nonce"] = Guid.NewGuid().ToString()
-        };
-        var signature = Sign(payload);
-        var envelope = new { payload, signature };
-        var json = JsonSerializer.Serialize(envelope);
-        _writer!.WriteLine(json);          // WriteLine appends \n (the required frame delimiter)
-        return _reader!.ReadLine() ?? "";  // ReadLine reads until \n
-    }
-
-    private string Sign(Dictionary<string, object> payload)
-    {
-        var sorted = new SortedDictionary<string, object>(payload);
-        var json = JsonSerializer.Serialize(sorted, new JsonSerializerOptions { WriteIndented = false });
-        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(_secret));
-        var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(json));
-        return BitConverter.ToString(hash).Replace("-", "").ToLower();
-    }
-
-    public void Dispose() { _client?.Dispose(); }
-}
-
-// Usage — same code, just change the host:
-// Same device:   new KioskTcpClient(host: "127.0.0.1")
-// LAN:           new KioskTcpClient(host: "192.168.1.100")
-// Internet:      new KioskTcpClient(host: "pos.merchant.com")
-
-class Program
-{
-    static void Main()
-    {
-        using var client = new KioskTcpClient(host: "127.0.0.1");
-        client.Connect();
-        var txnId = $"TXN{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
-        var response = client.SendPayment(txnId, 50.0, "card");
-        Console.WriteLine($"POS response: {response}");
-    }
-}
-```
-
-### Python (Reference / Testing)
-
-See `kiosk.py` in this repository for the full reference server implementation, and `TESTING.md` for a minimal Python POS client example.
-
----
-
-*For installation, testing procedures, and troubleshooting, refer to [TESTING.md](TESTING.md)*
+*For platform-specific integration code → [QUICKSTART.md](QUICKSTART.md)*
+*For testing procedures and troubleshooting → [TESTING.md](TESTING.md)*

--- a/pos-kiosk-integration/QUICKSTART.md
+++ b/pos-kiosk-integration/QUICKSTART.md
@@ -1,0 +1,655 @@
+# MobyPay POS-KIOSK Quick Start Guide
+
+Get from zero to a working POS integration in under 5 minutes — on any platform, any deployment topology.
+
+---
+
+## How it works
+
+The **Kiosk app is the TCP server**. The **POS app is the TCP client**. The POS connects to the Kiosk, receives payment requests, processes them, and sends results back. The protocol is identical everywhere — only the IP address changes.
+
+```
+POS (your code)  ──── TCP connect ────→  Kiosk server
+                 ←─── payment request ──
+                 ──── ACK + result ────→
+```
+
+| Where are Kiosk + POS? | POS connects to |
+|---|---|
+| Same device | `127.0.0.1:8080` |
+| Same LAN | `192.168.1.100:8080` (Kiosk's IP) |
+| Over internet | `yourkiosk.domain.com:8080` |
+
+---
+
+## Step 1 — Start the Kiosk Server
+
+```bash
+# Requires Python 3.7+ — no extra packages needed
+cd pos-kiosk-integration
+python3 kiosk.py
+```
+
+```
+Enter port (default 8080): [press Enter]
+🚀 Server started on 192.168.1.100:8080
+📱 Connect your POS terminal to: 192.168.1.100:8080
+```
+
+> **Same-device test:** connect to `127.0.0.1:8080` from your POS, regardless of the IP shown above.
+
+---
+
+## Step 2 — Integrate Your POS (pick your platform)
+
+---
+
+### 🤖 Android (Kotlin)
+
+#### AndroidManifest.xml
+
+```xml
+<!-- Required for TCP — even for localhost connections -->
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+For LAN connections on Android API 28+, add a network security config:
+
+```xml
+<!-- res/xml/network_security_config.xml -->
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="false">192.168.1.100</domain>
+  </domain-config>
+</network-security-config>
+```
+
+```xml
+<!-- AndroidManifest.xml <application> tag -->
+<application android:networkSecurityConfig="@xml/network_security_config" ...>
+```
+
+#### MobyPosClient.kt
+
+```kotlin
+import java.net.Socket
+import java.io.*
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import org.json.JSONObject
+import java.util.UUID
+
+class MobyPosClient(
+    private val host: String,           // "127.0.0.1" (same device) | "192.168.1.x" (LAN) | hostname (internet)
+    private val port: Int = 8080,
+    private val secret: String,         // must match Kiosk secret — never hardcode in production
+    private val kioskId: String = "KIOSK001"
+) {
+    private var socket: Socket? = null
+    private var writer: PrintWriter? = null
+    private var reader: BufferedReader? = null
+
+    fun connect() {
+        socket = Socket(host, port)
+        writer = PrintWriter(BufferedWriter(OutputStreamWriter(socket!!.getOutputStream())), true)
+        reader = BufferedReader(InputStreamReader(socket!!.getInputStream()))
+    }
+
+    fun disconnect() { socket?.close() }
+
+    // ── Main entry point: called when Kiosk sends a payment request ──────────────
+    // Run this in a background thread / coroutine — it blocks on readLine()
+    fun listenAndRespond(
+        onRequest: (txnId: String, amount: Double, paymentMode: String) -> TransactionResult,
+        onCancel: (txnId: String) -> Unit = {}
+    ) {
+        while (true) {
+            val raw = reader?.readLine() ?: break  // blocks until \n received
+            val msg = JSONObject(raw)
+            if (!verify(msg)) { /* drop invalid/tampered messages */ continue }
+
+            val payload = msg.getJSONObject("payload")
+            when (payload.getString("type")) {
+                "transaction_request" -> {
+                    val txnId = payload.getString("txn_id")
+                    val amount = payload.getDouble("amount")
+                    val mode = payload.getString("payment_mode")
+
+                    sendAck(txnId)                        // Step 1: ACK immediately
+                    val result = onRequest(txnId, amount, mode)  // Step 2: process payment
+                    sendResult(txnId, result)             // Step 3: send result
+                }
+                "cancel_transaction" -> {
+                    val txnId = payload.getString("txn_id")
+                    sendAck(txnId)
+                    onCancel(txnId)
+                }
+                "ipp_plan_selection" -> {
+                    val txnId = payload.getString("txn_id")
+                    val planId = payload.getString("plan_id")
+                    sendAck(txnId)
+                    // process the selected IPP plan here, then send result
+                }
+            }
+        }
+    }
+
+    private fun sendAck(txnId: String) = send(mapOf(
+        "type" to "ack", "txn_id" to txnId, "status" to "processing"
+    ))
+
+    fun sendResult(txnId: String, result: TransactionResult) = send(when (result) {
+        is TransactionResult.Success -> mapOf(
+            "type" to "transaction_result", "txn_id" to txnId,
+            "status" to "success",
+            "authorization_code" to result.authCode,
+            "card_last4" to result.cardLast4
+        )
+        is TransactionResult.Failed -> mapOf(
+            "type" to "transaction_result", "txn_id" to txnId,
+            "status" to "failed"
+        )
+        is TransactionResult.IppPlans -> mapOf(
+            "type" to "transaction_result", "txn_id" to txnId,
+            "status" to "ipp_plans",
+            "amount" to result.amount,
+            "plans" to result.plans
+        )
+    })
+
+    private fun send(data: Map<String, Any>) {
+        val payload = JSONObject(data).apply {
+            put("timestamp", System.currentTimeMillis().toString())
+            put("nonce", UUID.randomUUID().toString())
+        }
+        val envelope = JSONObject()
+        envelope.put("payload", payload)
+        envelope.put("signature", sign(payload))
+        writer?.println(envelope.toString())   // println appends \n (frame delimiter)
+    }
+
+    private fun sign(payload: JSONObject): String {
+        val sorted = payload.keys().asSequence().sorted()
+            .joinToString(",", "{", "}") { key ->
+                val v = payload.get(key)
+                "\"$key\":" + if (v is String) "\"$v\"" else v.toString()
+            }
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+        return mac.doFinal(sorted.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+    }
+
+    private fun verify(msg: JSONObject): Boolean {
+        val payload = msg.optJSONObject("payload") ?: return false
+        val received = msg.optString("signature")
+        return sign(payload) == received
+    }
+}
+
+// Result types — map these to your payment SDK's response
+sealed class TransactionResult {
+    data class Success(val authCode: String, val cardLast4: String) : TransactionResult()
+    object Failed : TransactionResult()
+    data class IppPlans(val amount: Double, val plans: List<Map<String, Any>>) : TransactionResult()
+}
+```
+
+#### Usage
+
+```kotlin
+// In a ViewModel or Service — run on a background coroutine
+viewModelScope.launch(Dispatchers.IO) {
+    val client = MobyPosClient(
+        host = "127.0.0.1",         // same device
+        // host = "192.168.1.100",  // LAN
+        secret = BuildConfig.MOBY_SECRET
+    )
+    client.connect()
+
+    client.listenAndRespond(
+        onRequest = { txnId, amount, paymentMode ->
+            // Call your payment SDK here
+            // Return the result:
+            TransactionResult.Success(authCode = "AUTH123", cardLast4 = "4242")
+        },
+        onCancel = { txnId ->
+            // Cancel any in-progress payment SDK call
+        }
+    )
+}
+```
+
+---
+
+### 🍎 iOS / Swift
+
+#### Info.plist
+
+```xml
+<!-- Required for LAN access -->
+<key>NSLocalNetworkUsageDescription</key>
+<string>Required to communicate with the MobyPay Kiosk terminal on your local network.</string>
+```
+
+#### MobyPosClient.swift
+
+```swift
+import Network
+import Foundation
+import CryptoKit
+
+class MobyPosClient {
+    private var connection: NWConnection?
+    private var receiveBuffer = Data()
+
+    let host: String       // "127.0.0.1" (same device) | LAN IP | hostname
+    let port: UInt16
+    let secret: String
+    let kioskId: String
+
+    var onTransactionRequest: ((String, Double, String) -> Void)?  // (txnId, amount, paymentMode)
+    var onCancelRequest: ((String) -> Void)?
+
+    init(host: String = "127.0.0.1", port: UInt16 = 8080,
+         secret: String, kioskId: String = "KIOSK001") {
+        self.host = host; self.port = port
+        self.secret = secret; self.kioskId = kioskId
+    }
+
+    func connect(onReady: @escaping () -> Void) {
+        let ep = NWEndpoint.hostPort(host: NWEndpoint.Host(host),
+                                     port: NWEndpoint.Port(rawValue: port)!)
+        connection = NWConnection(to: ep, using: .tcp)
+        connection?.stateUpdateHandler = { [weak self] state in
+            if case .ready = state {
+                onReady()
+                self?.receive()     // start listening loop
+            }
+        }
+        connection?.start(queue: .global(qos: .userInitiated))
+    }
+
+    // ── Receive loop — reads newline-delimited JSON frames ────────────────────────
+    private func receive() {
+        connection?.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, _ in
+            guard let self = self, let data = data else { return }
+            self.receiveBuffer.append(data)
+
+            // Process all complete \n-delimited messages in the buffer
+            while let newlineRange = self.receiveBuffer.firstRange(of: Data("\n".utf8)) {
+                let msgData = self.receiveBuffer.subdata(in: self.receiveBuffer.startIndex..<newlineRange.lowerBound)
+                self.receiveBuffer.removeSubrange(self.receiveBuffer.startIndex...newlineRange.upperBound - 1)
+                if let json = try? JSONSerialization.jsonObject(with: msgData) as? [String: Any] {
+                    self.handleMessage(json)
+                }
+            }
+            if !isComplete { self.receive() }
+        }
+    }
+
+    private func handleMessage(_ msg: [String: Any]) {
+        guard let payload = msg["payload"] as? [String: Any],
+              let signature = msg["signature"] as? String,
+              sign(payload) == signature else { return }  // drop if invalid signature
+
+        guard let type = payload["type"] as? String,
+              let txnId = payload["txn_id"] as? String else { return }
+
+        switch type {
+        case "transaction_request":
+            let amount = payload["amount"] as? Double ?? 0
+            let mode = payload["payment_mode"] as? String ?? ""
+            sendAck(txnId: txnId)
+            DispatchQueue.main.async { self.onTransactionRequest?(txnId, amount, mode) }
+
+        case "cancel_transaction":
+            sendAck(txnId: txnId)
+            DispatchQueue.main.async { self.onCancelRequest?(txnId) }
+
+        default: break
+        }
+    }
+
+    func sendSuccess(txnId: String, authCode: String, cardLast4: String) {
+        send(["type": "transaction_result", "txn_id": txnId,
+              "status": "success", "authorization_code": authCode, "card_last4": cardLast4])
+    }
+
+    func sendFailed(txnId: String) {
+        send(["type": "transaction_result", "txn_id": txnId, "status": "failed"])
+    }
+
+    private func sendAck(txnId: String) {
+        send(["type": "ack", "txn_id": txnId, "status": "processing"])
+    }
+
+    private func send(_ data: [String: Any]) {
+        var payload = data
+        payload["timestamp"] = String(Int(Date().timeIntervalSince1970 * 1000))
+        payload["nonce"] = UUID().uuidString
+        payload["kiosk_id"] = kioskId
+        let signature = sign(payload)
+        guard var msgData = try? JSONSerialization.data(withJSONObject: ["payload": payload, "signature": signature]) else { return }
+        msgData.append(contentsOf: "\n".utf8)   // newline frame delimiter
+        connection?.send(content: msgData, completion: .idempotent)
+    }
+
+    private func sign(_ payload: [String: Any]) -> String {
+        let sorted = payload.keys.sorted().map { key -> String in
+            let val = payload[key]!
+            let v = val is String ? "\"\(val)\"" : "\(val)"
+            return "\"\(key)\":$v"
+        }.joined(separator: ",")
+        let json = "{\(sorted)}"
+        let key = SymmetricKey(data: Data(secret.utf8))
+        return HMAC<SHA256>.authenticationCode(for: Data(json.utf8), using: key)
+            .map { String(format: "%02x", $0) }.joined()
+    }
+}
+```
+
+#### Usage
+
+```swift
+let client = MobyPosClient(
+    host: "127.0.0.1",     // same device
+    // host: "192.168.1.100",   // LAN
+    secret: Secrets.mobySecret
+)
+
+client.onTransactionRequest = { txnId, amount, paymentMode in
+    // Call your payment SDK here, then:
+    client.sendSuccess(txnId: txnId, authCode: "AUTH123", cardLast4: "4242")
+    // or on failure: client.sendFailed(txnId: txnId)
+}
+
+client.onCancelRequest = { txnId in
+    // Cancel any in-progress payment SDK call
+}
+
+client.connect {
+    print("Connected to Kiosk — ready to receive payment requests")
+}
+```
+
+---
+
+### 🪟 Windows / C# (.NET)
+
+#### MobyPosClient.cs
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class MobyPosClient : IDisposable
+{
+    private TcpClient? _client;
+    private StreamReader? _reader;
+    private StreamWriter? _writer;
+
+    public string Host { get; }         // "127.0.0.1" (same device) | LAN IP | hostname
+    public int Port { get; }
+    private readonly string _secret;
+    private readonly string _kioskId;
+
+    // Callbacks — wire these up before calling ConnectAsync()
+    public Func<string, double, string, Task<TxnResult>>? OnTransactionRequest { get; set; }
+    public Func<string, Task>? OnCancelRequest { get; set; }
+
+    public MobyPosClient(string host = "127.0.0.1", int port = 8080,
+                         string secret = "REPLACE-IN-PRODUCTION",
+                         string kioskId = "KIOSK001")
+    {
+        Host = host; Port = port; _secret = secret; _kioskId = kioskId;
+    }
+
+    public async Task ConnectAsync()
+    {
+        _client = new TcpClient();
+        await _client.ConnectAsync(Host, Port);
+        var stream = _client.GetStream();
+        _reader = new StreamReader(stream);
+        _writer = new StreamWriter(stream) { AutoFlush = true };
+    }
+
+    // ── Main listen loop — call after ConnectAsync() ──────────────────────────────
+    public async Task ListenAsync()
+    {
+        while (true)
+        {
+            var raw = await _reader!.ReadLineAsync();   // blocks until \n received
+            if (raw == null) break;
+
+            using var doc = JsonDocument.Parse(raw);
+            var root = doc.RootElement;
+            var payload = root.GetProperty("payload");
+            var receivedSig = root.GetProperty("signature").GetString() ?? "";
+
+            if (!Verify(payload, receivedSig)) continue; // drop tampered messages
+
+            var type = payload.GetProperty("type").GetString();
+            var txnId = payload.GetProperty("txn_id").GetString() ?? "";
+
+            switch (type)
+            {
+                case "transaction_request":
+                    var amount = payload.GetProperty("amount").GetDouble();
+                    var mode = payload.GetProperty("payment_mode").GetString() ?? "";
+                    await SendAck(txnId);
+                    if (OnTransactionRequest != null)
+                    {
+                        var result = await OnTransactionRequest(txnId, amount, mode);
+                        await SendResult(txnId, result);
+                    }
+                    break;
+
+                case "cancel_transaction":
+                    await SendAck(txnId);
+                    if (OnCancelRequest != null) await OnCancelRequest(txnId);
+                    break;
+            }
+        }
+    }
+
+    public async Task SendResult(string txnId, TxnResult result)
+    {
+        var data = result switch
+        {
+            TxnResult.Success s => new Dictionary<string, object>
+            {
+                ["type"] = "transaction_result", ["txn_id"] = txnId,
+                ["status"] = "success", ["authorization_code"] = s.AuthCode,
+                ["card_last4"] = s.CardLast4
+            },
+            TxnResult.Failed => new Dictionary<string, object>
+            {
+                ["type"] = "transaction_result", ["txn_id"] = txnId, ["status"] = "failed"
+            },
+            _ => throw new ArgumentException("Unknown result type")
+        };
+        await Send(data);
+    }
+
+    private Task SendAck(string txnId) => Send(new Dictionary<string, object>
+    {
+        ["type"] = "ack", ["txn_id"] = txnId, ["status"] = "processing"
+    });
+
+    private async Task Send(Dictionary<string, object> data)
+    {
+        data["timestamp"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+        data["nonce"] = Guid.NewGuid().ToString();
+        data["kiosk_id"] = _kioskId;
+
+        var signature = Sign(data);
+        var envelope = new { payload = data, signature };
+        var json = JsonSerializer.Serialize(envelope);
+        await _writer!.WriteLineAsync(json);    // WriteLine appends \n (frame delimiter)
+    }
+
+    private string Sign(Dictionary<string, object> payload)
+    {
+        var sorted = new SortedDictionary<string, object>(payload);
+        var json = JsonSerializer.Serialize(sorted, new JsonSerializerOptions { WriteIndented = false });
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(_secret));
+        return BitConverter.ToString(hmac.ComputeHash(Encoding.UTF8.GetBytes(json)))
+            .Replace("-", "").ToLower();
+    }
+
+    private bool Verify(JsonElement payload, string receivedSignature)
+    {
+        // Rebuild the canonical payload dict for signing
+        var dict = new SortedDictionary<string, object>();
+        foreach (var prop in payload.EnumerateObject())
+        {
+            dict[prop.Name] = prop.Value.ValueKind switch
+            {
+                JsonValueKind.Number => (object)prop.Value.GetDouble(),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                _ => prop.Value.GetString() ?? ""
+            };
+        }
+        var json = JsonSerializer.Serialize(dict, new JsonSerializerOptions { WriteIndented = false });
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(_secret));
+        var expected = BitConverter.ToString(hmac.ComputeHash(Encoding.UTF8.GetBytes(json)))
+            .Replace("-", "").ToLower();
+        return expected == receivedSignature;
+    }
+
+    public void Dispose() => _client?.Dispose();
+}
+
+// Result types
+public abstract record TxnResult
+{
+    public sealed record Success(string AuthCode, string CardLast4) : TxnResult;
+    public sealed record Failed : TxnResult;
+}
+```
+
+#### Usage
+
+```csharp
+using var client = new MobyPosClient(
+    host: "127.0.0.1",       // same device
+    // host: "192.168.1.100",   // LAN
+    secret: Environment.GetEnvironmentVariable("MOBY_SECRET")!
+);
+
+client.OnTransactionRequest = async (txnId, amount, paymentMode) =>
+{
+    Console.WriteLine($"Payment request: {paymentMode} RM{amount:F2} [{txnId}]");
+
+    // Call your payment hardware SDK here...
+    // Return the result:
+    return new TxnResult.Success(AuthCode: "AUTH123", CardLast4: "4242");
+    // or: return new TxnResult.Failed();
+};
+
+client.OnCancelRequest = async txnId =>
+{
+    Console.WriteLine($"Cancel request for {txnId}");
+    // Cancel any in-progress hardware transaction
+};
+
+await client.ConnectAsync();
+Console.WriteLine($"Connected to Kiosk at {client.Host}:{client.Port}");
+await client.ListenAsync();  // runs until disconnected
+```
+
+---
+
+### 🐍 Python (testing & scripting)
+
+For full Python POS simulator code, see **[TESTING.md → Example POS Test Client](TESTING.md#example-pos-test-client)**.
+
+```python
+# Minimal Python example — change KIOSK_HOST to match your deployment
+KIOSK_HOST = "127.0.0.1"      # same device
+# KIOSK_HOST = "192.168.1.100" # LAN
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.connect((KIOSK_HOST, 8080))
+reader = sock.makefile('r')
+
+while True:
+    raw = reader.readline()          # blocks until \n received
+    request = json.loads(raw)
+    txn_id = request['payload']['txn_id']
+
+    # ACK → process → result
+    sock.send(build_message("ack", txn_id, status="processing"))
+    sock.send(build_message("transaction_result", txn_id,
+                            status="success", authorization_code="AUTH123"))
+```
+
+---
+
+## Step 3 — Test All Payment Modes
+
+From the **Kiosk server interactive menu**, test each payment mode:
+
+| Menu option | `payment_mode` sent | Your POS should respond with |
+|---|---|---|
+| 1. Card Payment | `card` | ACK → `transaction_result` status `success` |
+| 2. BNPL | `bnpl` | ACK → `transaction_result` status `success` |
+| 3. DuitNow QR | `duitnow_qr` | ACK → `transaction_result` status `success` |
+| 4. IPP | `ipp` | ACK → `transaction_result` status `ipp_plans` → user selects → `success` |
+| 5. Cancel | — | ACK the cancel |
+
+---
+
+## Step 4 — Transaction Result Fields
+
+Your POS sends these fields back in the `transaction_result` payload:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | string | ✅ | Always `"transaction_result"` |
+| `txn_id` | string | ✅ | Must match the request's `txn_id` |
+| `status` | string | ✅ | `success` / `approved` / `failed` / `ipp_plans` |
+| `authorization_code` | string | Card/BNPL | Auth code from payment network |
+| `card_last4` | string | Card | Last 4 digits of card |
+| `plans` | array | IPP only | Array of installment plan objects |
+| `timestamp` | string | ✅ | Milliseconds since epoch |
+| `nonce` | string | ✅ | Unique UUID v4 per message |
+
+---
+
+## Step 5 — Go-Live Checklist
+
+```
+□ Replace POS-KIOSK-SECRET-KEY-2024 with a securely generated secret (min 32 chars)
+□ Store the secret in environment variables or a secrets manager — never in source code
+□ Enable NTP on both Kiosk and POS devices (clocks must be within 60 seconds)
+□ For internet deployments: wrap TCP in TLS or use a VPN
+□ For Android: INTERNET permission + network_security_config.xml for your Kiosk's IP
+□ For iOS: NSLocalNetworkUsageDescription in Info.plist
+□ Verify all 5 payment modes work end-to-end in staging
+□ Test reconnection: kill the Kiosk server and verify POS reconnects automatically
+□ Test cancellation: send a cancel mid-transaction and verify state resets correctly
+```
+
+---
+
+## Troubleshooting Quick Reference
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Can't connect | Wrong IP or port blocked | Use `nc -zv <host> 8080` to test; check firewall |
+| Signature validation failed | Secret mismatch | Ensure both sides use the same secret; verify JSON key sort order |
+| Timestamp expired | Clock drift | Enable NTP on both devices |
+| No response from Kiosk | Not connected | Check Kiosk Status (menu option 6) shows 1+ connected terminals |
+| Android: cleartext not permitted | API 28+ restriction | Add `network_security_config.xml` (see [INTEGRATION.md](INTEGRATION.md#android-network-security)) |
+
+For detailed testing procedures → [TESTING.md](TESTING.md)
+For full API reference → [INTEGRATION.md](INTEGRATION.md)

--- a/pos-kiosk-integration/README.md
+++ b/pos-kiosk-integration/README.md
@@ -1,41 +1,143 @@
 # MobyPay POS-KIOSK Integration
 
-Secure TCP communication system for integrating MobyPay Kiosk with POS terminals. Supports card payments, Buy Now Pay Later (BNPL), DuitNow QR, and Installment Payment Plans (IPP).
+Secure TCP communication between a MobyPay Kiosk and any POS terminal — on the **same device**, same LAN, or over the internet. Supports Card, BNPL, DuitNow QR, and IPP payments.
 
-> **Universal Deployment:** The same protocol works whether your Kiosk and POS are on the **same device**, on the **same LAN**, or connected over the **internet**. Only the IP address changes.
+---
+
+## ⚡ 5-Minute Quick Start
+
+> **New here? Start with this.** Connect your POS to the Kiosk and run your first transaction in 5 steps.
+
+### Step 1 — Run the Kiosk server
+
+Requires Python 3.7+. No extra packages needed.
+
+```bash
+git clone https://github.com/MobyPayTech/moby-plugins.git
+cd moby-plugins/pos-kiosk-integration
+python3 kiosk.py
+# → Enter port (default 8080): [press Enter]
+# → 🚀 Server started on 192.168.1.100:8080
+```
+
+### Step 2 — Connect your POS (pick your platform)
+
+**Same device?** Use `127.0.0.1`. **Different device?** Use the IP shown above.
+
+<details>
+<summary>🤖 Android (Kotlin)</summary>
+
+```kotlin
+val client = MobyPosClient(host = "127.0.0.1") // or "192.168.1.100" for LAN
+client.connect()
+```
+
+Full example → [Android](#android-kotlin)
+</details>
+
+<details>
+<summary>🍎 iOS (Swift)</summary>
+
+```swift
+let client = MobyPosClient(host: "127.0.0.1") // or "192.168.1.100" for LAN
+client.connect { /* on ready */ }
+```
+
+Full example → [iOS](#ios--swift)
+</details>
+
+<details>
+<summary>🪟 Windows / C# (.NET)</summary>
+
+```csharp
+using var client = new MobyPosClient(host: "127.0.0.1"); // or "192.168.1.100" for LAN
+client.Connect();
+```
+
+Full example → [Windows](#windows--c-net)
+</details>
+
+<details>
+<summary>🐍 Python (testing/scripting)</summary>
+
+```python
+import socket, json, hmac, hashlib, uuid
+from datetime import datetime
+
+KIOSK_HOST = "127.0.0.1"   # same device
+# KIOSK_HOST = "192.168.1.100"  # LAN
+KIOSK_PORT = 8080
+SECRET     = "POS-KIOSK-SECRET-KEY-2024"  # replace in production
+```
+
+Full example → [TESTING.md](TESTING.md#example-pos-test-client)
+</details>
+
+### Step 3 — Send a payment request
+
+From the **Kiosk server menu**, select a payment method and enter an amount:
+
+```
+📋 Available Commands:
+1. 💳 Card Payment       → select 1, enter amount e.g. 25.50
+2. 🛒 BNPL              → select 2
+3. 📱 DuitNow QR        → select 3
+4. 🏦 IPP               → select 4
+5. 🚫 Cancel Transaction
+```
+
+### Step 4 — Handle the response on your POS
+
+Your POS receives a signed JSON message over TCP and sends back an ACK + result:
+
+```json
+// Kiosk → POS: payment request
+{ "payload": { "type": "transaction_request", "txn_id": "TXN1705123456789",
+               "amount": 25.50, "payment_mode": "card", ... }, "signature": "..." }
+
+// POS → Kiosk: acknowledge
+{ "payload": { "type": "ack", "txn_id": "TXN1705123456789", "status": "processing", ... }, "signature": "..." }
+
+// POS → Kiosk: final result
+{ "payload": { "type": "transaction_result", "txn_id": "TXN1705123456789",
+               "status": "success", "authorization_code": "AUTH123", ... }, "signature": "..." }
+```
+
+### Step 5 — Go live checklist
+
+Before deploying to production:
+
+- [ ] Replace `POS-KIOSK-SECRET-KEY-2024` with a securely generated secret (min 32 chars)
+- [ ] Enable NTP on both Kiosk and POS devices (clocks must be within 60 seconds)
+- [ ] For internet-facing deployments: wrap TCP in TLS or use a VPN
+- [ ] For Android: add `INTERNET` permission and network security config for your Kiosk IP
+- [ ] Test all payment modes: `card`, `bnpl`, `duitnow_qr`, `ipp`
 
 ---
 
 ## 📚 Documentation
 
-- **[INTEGRATION.md](INTEGRATION.md)** — API specs, system architecture, security model, same-device vs remote deployment, and platform code examples (Android, iOS, Windows)
-- **[TESTING.md](TESTING.md)** — Installation, testing procedures for all deployment scenarios, and a complete Python POS test client
-- **[kiosk.py](kiosk.py)** — Reference implementation (TCP server with interactive menu)
-- **[POS - KIOSK Integration.pdf](POS%20-%20KIOSK%20Integration.pdf)** — Detailed technical reference
-
----
-
-## ✨ Features
-
-- **Universal TCP protocol** — identical on same-device, LAN, and internet deployments
-- **Cross-platform** — Windows, Android, iOS, Linux, and embedded POS systems
-- **Secure messaging** — HMAC-SHA256 signing and nonce validation
-- **Multiple payment methods** — Card, BNPL, DuitNow QR, and IPP
-- **Real-time transaction processing**
-- **Replay attack protection** — 60-second timestamp validation + nonce tracking
-- **Multiple concurrent POS connections**
-- **IPP plan selection** with installment details
-
----
-
-## 🚀 Quick Start
-
-| I want to... | Start here |
+| Document | What's inside |
 |---|---|
-| Understand the architecture & API | [INTEGRATION.md](INTEGRATION.md) |
-| Test the integration on my machine | [TESTING.md](TESTING.md) |
-| Integrate from Android / iOS / Windows | [INTEGRATION.md → Platform Examples](INTEGRATION.md#platform-integration-examples) |
+| **[QUICKSTART.md](QUICKSTART.md)** | Platform-by-platform setup guide with full working code |
+| **[INTEGRATION.md](INTEGRATION.md)** | Full API reference, message formats, security model, architecture |
+| **[TESTING.md](TESTING.md)** | Test scenarios, Python POS simulator, troubleshooting |
+| **[kiosk.py](kiosk.py)** | Reference Kiosk server implementation |
+| **[POS - KIOSK Integration.pdf](POS%20-%20KIOSK%20Integration.pdf)** | Printable technical reference |
 
 ---
 
-> ⚠️ This is a secure payment integration. Always use a production-grade secret key, synchronized clocks (NTP), and TLS for internet-facing deployments.
+## ✨ Feature Summary
+
+| Feature | Detail |
+|---|---|
+| **Protocol** | TCP with newline-delimited JSON |
+| **Security** | HMAC-SHA256 signing + nonce + 60s timestamp window |
+| **Platforms** | Android, iOS, Windows, Linux, embedded POS |
+| **Deployment** | Same-device (127.0.0.1), LAN, or internet |
+| **Payment methods** | Card, BNPL, DuitNow QR, IPP |
+| **Concurrent POS** | Multiple POS terminals per Kiosk |
+
+---
+
+> ⚠️ Always use a production-grade secret key, NTP-synced clocks, and TLS for internet-facing deployments.

--- a/pos-kiosk-integration/README.md
+++ b/pos-kiosk-integration/README.md
@@ -1,23 +1,41 @@
 # MobyPay POS-KIOSK Integration
 
-Secure TCP communication system for MobyPay Kiosk integration with POS terminals. Supports card payments, Buy Now Pay Later (BNPL), DuitNow QR, and Installment Payment Plans (IPP).
+Secure TCP communication system for integrating MobyPay Kiosk with POS terminals. Supports card payments, Buy Now Pay Later (BNPL), DuitNow QR, and Installment Payment Plans (IPP).
 
-## 📚 Documentation
-
-- **[INTEGRATION.md](./INTEGRATION.md)** - API specs, system architecture, security model, and workflows
-- **[TESTING.md](./TESTING.md)** - Installation, usage, testing procedures, and troubleshooting
-- `kiosk.py` - Reference implementation (TCP server with interactive menu)
-- `POS - KIOSK Integration.pdf` - Detailed technical reference
-
-## ✨ Features
-
-- Secure TCP with HMAC-SHA256 signing and nonce validation
-- Multiple payment methods (card, BNPL, DuitNow QR, IPP)
-- Real-time transaction processing
-- Replay attack protection with 60-second timestamp validation
-- Multiple concurrent POS connections
-- IPP plan selection with installment details
+> **Universal Deployment:** The same protocol works whether your Kiosk and POS are on the **same device**, on the **same LAN**, or connected over the **internet**. Only the IP address changes.
 
 ---
 
-**Note:** This is a secure payment integration system. Always ensure proper security measures are in place in production environments, including network encryption, access controls, and audit logging.
+## 📚 Documentation
+
+- **[INTEGRATION.md](INTEGRATION.md)** — API specs, system architecture, security model, same-device vs remote deployment, and platform code examples (Android, iOS, Windows)
+- **[TESTING.md](TESTING.md)** — Installation, testing procedures for all deployment scenarios, and a complete Python POS test client
+- **[kiosk.py](kiosk.py)** — Reference implementation (TCP server with interactive menu)
+- **[POS - KIOSK Integration.pdf](POS%20-%20KIOSK%20Integration.pdf)** — Detailed technical reference
+
+---
+
+## ✨ Features
+
+- **Universal TCP protocol** — identical on same-device, LAN, and internet deployments
+- **Cross-platform** — Windows, Android, iOS, Linux, and embedded POS systems
+- **Secure messaging** — HMAC-SHA256 signing and nonce validation
+- **Multiple payment methods** — Card, BNPL, DuitNow QR, and IPP
+- **Real-time transaction processing**
+- **Replay attack protection** — 60-second timestamp validation + nonce tracking
+- **Multiple concurrent POS connections**
+- **IPP plan selection** with installment details
+
+---
+
+## 🚀 Quick Start
+
+| I want to... | Start here |
+|---|---|
+| Understand the architecture & API | [INTEGRATION.md](INTEGRATION.md) |
+| Test the integration on my machine | [TESTING.md](TESTING.md) |
+| Integrate from Android / iOS / Windows | [INTEGRATION.md → Platform Examples](INTEGRATION.md#platform-integration-examples) |
+
+---
+
+> ⚠️ This is a secure payment integration. Always use a production-grade secret key, synchronized clocks (NTP), and TLS for internet-facing deployments.

--- a/pos-kiosk-integration/README.md
+++ b/pos-kiosk-integration/README.md
@@ -1,143 +1,41 @@
 # MobyPay POS-KIOSK Integration
 
-Secure TCP communication between a MobyPay Kiosk and any POS terminal — on the **same device**, same LAN, or over the internet. Supports Card, BNPL, DuitNow QR, and IPP payments.
+Secure TCP communication system for integrating MobyPay Kiosk with POS terminals. Supports card payments, Buy Now Pay Later (BNPL), DuitNow QR, and Installment Payment Plans (IPP).
 
----
-
-## ⚡ 5-Minute Quick Start
-
-> **New here? Start with this.** Connect your POS to the Kiosk and run your first transaction in 5 steps.
-
-### Step 1 — Run the Kiosk server
-
-Requires Python 3.7+. No extra packages needed.
-
-```bash
-git clone https://github.com/MobyPayTech/moby-plugins.git
-cd moby-plugins/pos-kiosk-integration
-python3 kiosk.py
-# → Enter port (default 8080): [press Enter]
-# → 🚀 Server started on 192.168.1.100:8080
-```
-
-### Step 2 — Connect your POS (pick your platform)
-
-**Same device?** Use `127.0.0.1`. **Different device?** Use the IP shown above.
-
-<details>
-<summary>🤖 Android (Kotlin)</summary>
-
-```kotlin
-val client = MobyPosClient(host = "127.0.0.1") // or "192.168.1.100" for LAN
-client.connect()
-```
-
-Full example → [Android](#android-kotlin)
-</details>
-
-<details>
-<summary>🍎 iOS (Swift)</summary>
-
-```swift
-let client = MobyPosClient(host: "127.0.0.1") // or "192.168.1.100" for LAN
-client.connect { /* on ready */ }
-```
-
-Full example → [iOS](#ios--swift)
-</details>
-
-<details>
-<summary>🪟 Windows / C# (.NET)</summary>
-
-```csharp
-using var client = new MobyPosClient(host: "127.0.0.1"); // or "192.168.1.100" for LAN
-client.Connect();
-```
-
-Full example → [Windows](#windows--c-net)
-</details>
-
-<details>
-<summary>🐍 Python (testing/scripting)</summary>
-
-```python
-import socket, json, hmac, hashlib, uuid
-from datetime import datetime
-
-KIOSK_HOST = "127.0.0.1"   # same device
-# KIOSK_HOST = "192.168.1.100"  # LAN
-KIOSK_PORT = 8080
-SECRET     = "POS-KIOSK-SECRET-KEY-2024"  # replace in production
-```
-
-Full example → [TESTING.md](TESTING.md#example-pos-test-client)
-</details>
-
-### Step 3 — Send a payment request
-
-From the **Kiosk server menu**, select a payment method and enter an amount:
-
-```
-📋 Available Commands:
-1. 💳 Card Payment       → select 1, enter amount e.g. 25.50
-2. 🛒 BNPL              → select 2
-3. 📱 DuitNow QR        → select 3
-4. 🏦 IPP               → select 4
-5. 🚫 Cancel Transaction
-```
-
-### Step 4 — Handle the response on your POS
-
-Your POS receives a signed JSON message over TCP and sends back an ACK + result:
-
-```json
-// Kiosk → POS: payment request
-{ "payload": { "type": "transaction_request", "txn_id": "TXN1705123456789",
-               "amount": 25.50, "payment_mode": "card", ... }, "signature": "..." }
-
-// POS → Kiosk: acknowledge
-{ "payload": { "type": "ack", "txn_id": "TXN1705123456789", "status": "processing", ... }, "signature": "..." }
-
-// POS → Kiosk: final result
-{ "payload": { "type": "transaction_result", "txn_id": "TXN1705123456789",
-               "status": "success", "authorization_code": "AUTH123", ... }, "signature": "..." }
-```
-
-### Step 5 — Go live checklist
-
-Before deploying to production:
-
-- [ ] Replace `POS-KIOSK-SECRET-KEY-2024` with a securely generated secret (min 32 chars)
-- [ ] Enable NTP on both Kiosk and POS devices (clocks must be within 60 seconds)
-- [ ] For internet-facing deployments: wrap TCP in TLS or use a VPN
-- [ ] For Android: add `INTERNET` permission and network security config for your Kiosk IP
-- [ ] Test all payment modes: `card`, `bnpl`, `duitnow_qr`, `ipp`
+> **Universal Deployment:** The same protocol works whether your Kiosk and POS are on the **same device**, on the **same LAN**, or connected over the **internet**. Only the IP address changes.
 
 ---
 
 ## 📚 Documentation
 
-| Document | What's inside |
-|---|---|
-| **[QUICKSTART.md](QUICKSTART.md)** | Platform-by-platform setup guide with full working code |
-| **[INTEGRATION.md](INTEGRATION.md)** | Full API reference, message formats, security model, architecture |
-| **[TESTING.md](TESTING.md)** | Test scenarios, Python POS simulator, troubleshooting |
-| **[kiosk.py](kiosk.py)** | Reference Kiosk server implementation |
-| **[POS - KIOSK Integration.pdf](POS%20-%20KIOSK%20Integration.pdf)** | Printable technical reference |
+- **[INTEGRATION.md](INTEGRATION.md)** — API specs, system architecture, security model, same-device vs remote deployment, and platform code examples (Android, iOS, Windows)
+- **[TESTING.md](TESTING.md)** — Installation, testing procedures for all deployment scenarios, and a complete Python POS test client
+- **[kiosk.py](kiosk.py)** — Reference implementation (TCP server with interactive menu)
+- **[POS - KIOSK Integration.pdf](POS%20-%20KIOSK%20Integration.pdf)** — Detailed technical reference
 
 ---
 
-## ✨ Feature Summary
+## ✨ Features
 
-| Feature | Detail |
-|---|---|
-| **Protocol** | TCP with newline-delimited JSON |
-| **Security** | HMAC-SHA256 signing + nonce + 60s timestamp window |
-| **Platforms** | Android, iOS, Windows, Linux, embedded POS |
-| **Deployment** | Same-device (127.0.0.1), LAN, or internet |
-| **Payment methods** | Card, BNPL, DuitNow QR, IPP |
-| **Concurrent POS** | Multiple POS terminals per Kiosk |
+- **Universal TCP protocol** — identical on same-device, LAN, and internet deployments
+- **Cross-platform** — Windows, Android, iOS, Linux, and embedded POS systems
+- **Secure messaging** — HMAC-SHA256 signing and nonce validation
+- **Multiple payment methods** — Card, BNPL, DuitNow QR, and IPP
+- **Real-time transaction processing**
+- **Replay attack protection** — 60-second timestamp validation + nonce tracking
+- **Multiple concurrent POS connections**
+- **IPP plan selection** with installment details
 
 ---
 
-> ⚠️ Always use a production-grade secret key, NTP-synced clocks, and TLS for internet-facing deployments.
+## 🚀 Quick Start
+
+| I want to... | Start here |
+|---|---|
+| Understand the architecture & API | [INTEGRATION.md](INTEGRATION.md) |
+| Test the integration on my machine | [TESTING.md](TESTING.md) |
+| Integrate from Android / iOS / Windows | [INTEGRATION.md → Platform Examples](INTEGRATION.md#platform-integration-examples) |
+
+---
+
+> ⚠️ This is a secure payment integration. Always use a production-grade secret key, synchronized clocks (NTP), and TLS for internet-facing deployments.

--- a/pos-kiosk-integration/TESTING.md
+++ b/pos-kiosk-integration/TESTING.md
@@ -2,23 +2,31 @@
 
 This guide covers testing procedures using the `kiosk.py` reference implementation. It includes installation, usage, manual testing, and troubleshooting.
 
+---
+
 ## 📋 Table of Contents
 
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Running the Kiosk Server](#running-the-kiosk-server)
 - [Interactive Menu](#interactive-menu)
-- [Manual Testing](#manual-testing)
 - [Testing Scenarios](#testing-scenarios)
 - [Connection Testing](#connection-testing)
 - [Security Testing](#security-testing)
 - [Troubleshooting](#troubleshooting)
+- [Example POS Test Client](#example-pos-test-client)
+
+---
 
 ## Requirements
 
 - Python 3.7 or higher
-- Network connectivity between kiosk and POS terminals
+- Network connectivity between Kiosk and POS terminals (or same device — see below)
 - Open TCP port for communication (default: 8080)
+
+> **Same-device testing:** If both the Kiosk server and your POS test client run on the same machine, use `127.0.0.1` as the connection address. No network setup is needed.
+
+---
 
 ## Installation
 
@@ -26,248 +34,126 @@ This guide covers testing procedures using the `kiosk.py` reference implementati
 
 **macOS:**
 ```bash
-# Using Homebrew (recommended)
 brew install python3
-
-# Or download from python.org
-# Visit: https://www.python.org/downloads/
+# Or download from https://www.python.org/downloads/
 ```
 
 **Windows:**
 ```bash
-# Download installer from python.org
-# Visit: https://www.python.org/downloads/
+# Download installer from https://www.python.org/downloads/
 # Make sure to check "Add Python to PATH" during installation
 ```
 
 **Linux (Ubuntu/Debian):**
 ```bash
-sudo apt update
-sudo apt install python3 python3-pip
+sudo apt update && sudo apt install python3 python3-pip
 ```
 
 **Linux (CentOS/RHEL):**
 ```bash
-sudo yum install python3 python3-pip
-# or for newer versions:
 sudo dnf install python3 python3-pip
 ```
 
 ### 2. Verify Python Installation
 
 ```bash
-python3 --version
-# Should show Python 3.7.x or higher
+python3 --version  # Should show Python 3.7.x or higher
 ```
 
-### 3. Clone/Download the Project
+### 3. Get the Files
 
 ```bash
-# If using git
-git clone <repository-url>
-cd pos-kiosk-integration
-
-# Or download and extract the files to this directory
+git clone https://github.com/MobyPayTech/moby-plugins.git
+cd moby-plugins/pos-kiosk-integration
 ```
 
 ### 4. Dependencies
 
-The kiosk system uses only Python standard library modules:
-- `socket` - TCP communication
-- `json` - Message formatting
-- `threading` - Concurrent connection handling
-- `hashlib` & `hmac` - Security and message signing
-- `uuid` - Nonce generation
-- `datetime` - Timestamp validation
+No external packages required. The kiosk system uses only Python standard library modules: `socket`, `json`, `threading`, `hashlib`, `hmac`, `uuid`, `datetime`.
 
-No external packages need to be installed.
+---
 
 ## Running the Kiosk Server
 
-### Starting the Server
+```bash
+cd pos-kiosk-integration
+python3 kiosk.py
+```
 
-1. **Navigate to the project directory:**
-   ```bash
-   cd pos-kiosk-integration
-   ```
+When prompted:
+```
+Enter port (default 8080): [Press Enter for default]
+```
 
-2. **Run the kiosk application:**
-   ```bash
-   python3 kiosk.py
-   ```
+On startup you will see the Kiosk's listening address:
+```
+🚀 Server started on 192.168.1.100:8080
+📱 Connect your POS terminal to: 192.168.1.100:8080
+```
 
-3. **Configure the server:**
-   ```
-   Enter port (default 8080): [Press Enter for default or enter custom port]
-   ```
+> **Same-device testing:** When your POS test client runs on the same machine, connect to `127.0.0.1:8080` regardless of the IP shown above.
 
-4. **Server startup confirmation:**
-   ```
-   🚀 Server started on 192.168.1.100:8080
-   📱 Connect your POS terminal to: 192.168.1.100:8080
-   ```
-
-The server is now ready to accept POS terminal connections.
+---
 
 ## Interactive Menu
-
-Once the server is running, you'll see the following menu:
 
 ```
 📋 Available Commands:
 1. 💳 Card Payment
 2. 🛒 Buy Now Pay Later (BNPL)
 3. 📱 DuitNow QR
-4. 🏦 Internet Banking (IPP)
+4. 🏦 Installment Payment Plan (IPP)
 5. 🚫 Cancel Transaction
 6. ℹ️  Show Status
 7. 🔴 Exit
 ```
 
-### Menu Options Explained
-
-- **1. Card Payment**: Initiate a card payment transaction
-- **2. BNPL**: Initiate a Buy Now Pay Later transaction
-- **3. DuitNow QR**: Initiate a DuitNow QR payment
-- **4. IPP**: Initiate an Installment Payment Plan transaction
-- **5. Cancel**: Cancel the current active transaction
-- **6. Status**: Display current server and connection status
-- **7. Exit**: Shut down the server and exit
-
-## Manual Testing
-
-### Basic Card Payment Test
-
-1. **Start the server:**
-   ```bash
-   python3 kiosk.py
-   ```
-
-2. **When prompted for port, press Enter** (to use default 8080)
-
-3. **Select option 1** (Card Payment)
-
-4. **Enter an amount when prompted:**
-   ```
-   Enter amount (RM): 25.50
-   ```
-
-5. **Expected output:**
-   ```
-   📤 Sending card payment request for RM25.50
-   🆔 Transaction ID: TXN1705123456789
-   ✅ Payment request sent to POS terminal
-   ```
-
-6. **Wait for POS response** (in a real scenario, this would come from a connected POS terminal)
-
-### Payment Method Test Sequence
-
-Test all payment methods in sequence:
-
-```
-1. Card Payment (amount: 10.00)
-   - Select option 1
-   - Enter: 10.00
-   - Verify: Transaction ID generated
-
-2. BNPL (amount: 20.00)
-   - Select option 2
-   - Enter: 20.00
-   - Verify: Correct payment mode sent
-
-3. DuitNow QR (amount: 15.50)
-   - Select option 3
-   - Enter: 15.50
-   - Verify: DuitNow QR request sent
-
-4. IPP (amount: 100.00)
-   - Select option 4
-   - Enter: 100.00
-   - Wait for plan selection if POS responds with plans
-```
-
-### Transaction Cancellation Test
-
-1. **Initiate a payment:**
-   ```
-   Select option (1-7): 1
-   Enter amount (RM): 50.00
-   ```
-
-2. **Before POS responds, select option 5:**
-   ```
-   Select option (1-7): 5
-   ```
-
-3. **Expected output:**
-   ```
-   🚫 Cancelling transaction: TXN1705123456789
-   ✅ Cancel request sent to POS terminal
-   ```
-
-### Status Display Test
-
-1. **Select option 6** from the main menu
-
-2. **Expected output:**
-   ```
-   📊 Status:
-   🔗 Connected POS terminals: 1
-   🆔 Current transaction: TXN1705123456789
-   👂 Listening for responses: True
-   🏪 Kiosk ID: KIOSK001
-   ```
+---
 
 ## Testing Scenarios
 
-### Scenario 1: Single POS Connection
+### Scenario 1: Same-Device Test (Kiosk + POS on one machine)
 
-**Setup:**
-1. Start kiosk server (port 8080)
-2. Connect one POS terminal to the server
+This is the quickest way to verify the integration without any network setup.
 
-**Test Steps:**
-1. Send card payment (RM 25.00)
-2. POS should acknowledge with "processing" status
-3. POS should respond with transaction result
-4. Verify status display shows 1 connected terminal
+1. Start the Kiosk server: `python3 kiosk.py`
+2. In a **second terminal**, run the Python POS test client (see [Example POS Test Client](#example-pos-test-client)) with `host = "127.0.0.1"`
+3. From the Kiosk menu, select option **1 (Card Payment)** and enter an amount
+4. The test client should receive the request, send an ACK, then send a success result
+5. The Kiosk should display the payment result
 
-**Expected Results:**
-- Message flow completes without errors
-- Transaction ID is generated correctly
-- Status is updated in real-time
+### Scenario 2: LAN Test (Kiosk + POS on different devices)
 
-### Scenario 2: Multiple POS Connections
+1. Note the IP address shown when the Kiosk server starts (e.g. `192.168.1.100:8080`)
+2. On the POS device, run the test client with `host = "192.168.1.100"`
+3. Verify the Kiosk shows **"🔗 Client connected from ..."** in its output
+4. Test all payment methods
 
-**Setup:**
-1. Start kiosk server (port 8080)
-2. Connect multiple POS terminals to the server
+### Scenario 3: Internet Test (remote POS)
 
-**Test Steps:**
-1. Send payment request
-2. Verify broadcast to all connected terminals
-3. Handle responses from multiple terminals
+1. Ensure the Kiosk's port 8080 is accessible from the internet (port forward or public IP)
+2. On the remote POS, run the test client with `host = "<kiosk-public-ip>"`
+3. Verify connectivity and test all payment methods
 
-**Expected Results:**
-- Status displays correct number of connected terminals
-- Requests are broadcast to all terminals
-- Each terminal can respond independently
+> For internet deployments, wrap the connection in TLS or a VPN in production. Raw TCP over the internet is unencrypted.
 
-### Scenario 3: IPP Plan Selection
+### Scenario 4: Card Payment
 
-**Setup:**
-1. Start kiosk server
-2. Connect POS terminal capable of IPP
+1. Start Kiosk server
+2. Connect POS test client (any topology)
+3. Select option **1** → enter amount e.g. `25.50`
+4. Expected Kiosk output:
+```
+📤 Sending card payment request for RM25.50
+🆔 Transaction ID: TXN1705123456789
+✅ Payment request sent to POS terminal
+```
 
-**Test Steps:**
-1. Select option 4 (IPP Payment)
-2. Enter amount (e.g., 100.00)
-3. Wait for POS to respond with available plans
-4. Display and select from available plans
-5. Verify plan selection is sent back
+### Scenario 5: IPP Plan Selection
 
-**Expected Results:**
+1. Connect POS test client that supports IPP plan responses
+2. Select option **4 (IPP)** → enter amount e.g. `100.00`
+3. POS responds with available plans:
 ```
 💰 Amount: RM100.00
 📋 Available Installment Plans:
@@ -276,227 +162,130 @@ Test all payment methods in sequence:
    Frequency: Monthly
    Total Installments: 3
    Installment Details:
-     #1: RM35.00 on 2024-02-15
-       Fee: RM1.50 (1.5%)
-     #2: RM35.00 on 2024-03-15
-       Fee: RM1.50 (1.5%)
-     #3: RM35.00 on 2024-04-15
-       Fee: RM1.50 (1.5%)
-
-Select plan (1-3) or 'q' to quit: 1
-✅ Selected Plan: IPP_3M
-📤 Sending plan selection: IPP_3M
-✅ Plan selection sent to terminal
+     #1: RM35.00 on 2024-02-15  Fee: RM1.50 (1.5%)
+     #2: RM35.00 on 2024-03-15  Fee: RM1.50 (1.5%)
+     #3: RM35.00 on 2024-04-15  Fee: RM1.50 (1.5%)
+Select plan (1-3) or 'q' to quit:
 ```
 
-### Scenario 4: Transaction with Various Amounts
+### Scenario 6: Transaction Cancellation
 
-Test transactions with different amount ranges:
+1. Initiate a payment (e.g. option 1, amount 50.00)
+2. Before the POS responds, select option **5 (Cancel)**
+3. Expected output:
+```
+🚫 Cancelling transaction: TXN1705123456789
+✅ Cancel request sent to POS terminal
+```
 
-| Amount | Purpose | Notes |
-|--------|---------|-------|
-| 0.01 | Minimum | Test handling of smallest amount |
-| 10.00 | Small | Typical small transaction |
-| 99.99 | Standard | Most common transaction size |
-| 999.99 | Large | Test larger amounts |
-| 5000.00 | Maximum | Test handling of max amounts |
+### Scenario 7: Amount Edge Cases
+
+| Amount | Purpose |
+|---|---|
+| 0.01 | Minimum — smallest valid amount |
+| 10.00 | Small transaction |
+| 99.99 | Standard transaction |
+| 999.99 | Large transaction |
+| 5000.00 | Maximum — verify upper bound handling |
+
+---
 
 ## Connection Testing
 
-### Check Server Status
+### Verify Port is Open
 
-**Using telnet (available on most systems):**
 ```bash
+# Using telnet
 telnet <kiosk-ip> 8080
 
-# Expected response:
-# Connected to <kiosk-ip>
-# Escape character is '^]'.
-```
-
-**Using netcat (if available):**
-```bash
+# Using netcat
 nc -zv <kiosk-ip> 8080
 
-# Expected response:
-# Connection to <kiosk-ip> port 8080 [tcp/*] succeeded!
+# Same-device check
+nc -zv 127.0.0.1 8080
 ```
 
-### Verify Network Connectivity
+### Check Connectivity
 
 ```bash
-# Ping the kiosk server
 ping <kiosk-ip>
-
-# Expected response:
-# PING <kiosk-ip> (<ip-address>): 56 data bytes
-# 64 bytes from <ip-address>: icmp_seq=0 ttl=64 time=2.123 ms
 ```
 
-### Monitor Live Connections
+### View Live Connections
 
-While the kiosk server is running, you can:
-1. Select option 6 (Show Status) to see connected terminals
-2. Check console output for connection events:
-   ```
-   🔗 Client connected from 192.168.1.50:54321
-   📨 Received from 192.168.1.50: {...}
-   🔌 Client 192.168.1.50 disconnected
-   ```
+From the Kiosk interactive menu, select **option 6 (Show Status)**:
+```
+📊 Status:
+🔗 Connected POS terminals: 1
+🆔 Current transaction: TXN1705123456789
+👂 Listening for responses: True
+🏪 Kiosk ID: KIOSK001
+```
+
+---
 
 ## Security Testing
 
-The system automatically validates the following security aspects:
+The system automatically validates these security aspects on every message:
 
 ### 1. Message Signature Validation
 
-- All received messages are verified using HMAC-SHA256
-- The signature is calculated over the sorted payload JSON
+All received messages are verified using HMAC-SHA256.
+
+- POS terminals must use the shared secret `POS-KIOSK-SECRET-KEY-2024` (for testing; replace in production)
 - Invalid signatures trigger security validation failures
 
-**Test:** POS Terminal should use the shared secret `POS-KIOSK-SECRET-KEY-2024` when signing messages.
-
-### 2. Nonce Validation
-
-- Each message includes a unique UUID v4 nonce
-- Nonces are tracked to prevent replay attacks
-- Duplicate nonces are rejected
-
-**Test Output:**
+**Expected output on valid signature:**
 ```
 🔐 Signature verification PASSED:
    ✅ Signature matches expected value
    📨 Signature: a1b2c3d4e5f6...xxxxxxxx
 ```
 
+**Expected output on invalid signature:**
+```
+🔐 Signature verification FAILED:
+   📨 Received signature: xxxx...
+   🔑 Expected signature: yyyy...
+🔒 Security validation failed: Invalid signature
+```
+
+### 2. Nonce Validation
+
+Each message uses a unique UUID v4 nonce. Duplicate nonces are rejected.
+
 ### 3. Timestamp Validation
 
-- Timestamps must be within a 60-second window
-- Timestamps are in milliseconds since epoch
-- Requests outside the window are rejected
+Timestamps must be within a 60-second window.
 
-**Test Output:**
 ```
 🕐 Timestamp validation - Request: 1705123456789, Current: 1705123458000, Diff: 1211ms
 ✅ Timestamp valid: Within 60 second window
 ```
 
-### Security Failure Examples
-
-**Invalid Signature:**
-```
-🔐 Signature verification FAILED:
-   📨 Received signature: xxxx...
-   🔑 Expected signature: yyyy...
-   ❌ Signatures match: False
-🔒 Security validation failed: Invalid signature
-```
-
-**Expired Timestamp:**
+**Expired timestamp:**
 ```
 ❌ Timestamp failed: Request too old/new (diff: 65000ms > 60000ms)
 🔒 Security validation failed: Request expired or invalid timestamp
 ```
 
+---
+
 ## Troubleshooting
 
-### Common Issues
+| Problem | Error | Solution |
+|---|---|---|
+| Port in use | `[Errno 48] Address already in use` | Run `lsof -i :8080` to find the process and kill it, or use a different port |
+| Permission denied | `[Errno 13] Permission denied` | Use a port > 1024; avoid privileged ports |
+| No POS connection | `❌ No POS terminals connected` | Verify IP/port, check firewall, run `ping <kiosk-ip>`, test port with telnet/nc |
+| Signature failure | `🔒 Security validation failed: Invalid signature` | Ensure both sides use the same shared secret; verify JSON is UTF-8 and keys are sorted |
+| Invalid JSON | `❌ JSON decode error` | Verify message ends with `\n`; validate JSON format; check for encoding issues |
+| Clock drift | `Timestamp failed: Request too old/new` | Sync device clocks via NTP |
 
-#### 1. Port Already in Use
+### Capture Debug Logs
 
-**Error:**
-```
-❌ Failed to start server: [Errno 48] Address already in use
-```
-
-**Solution:**
-```bash
-# Find process using the port
-lsof -i :8080
-
-# Kill the process (replace PID with actual process ID)
-kill -9 <PID>
-
-# Or use a different port when starting kiosk.py
-# When prompted, enter a different port number (e.g., 8081)
-```
-
-#### 2. Permission Denied
-
-**Error:**
-```
-❌ Failed to start server: [Errno 13] Permission denied
-```
-
-**Solution:**
-- Use a port number > 1024 (privileged ports like 80, 443, 8000-8100 may require admin)
-- On Linux/macOS, prefix with `sudo` if needed (not recommended for security reasons)
-- Choose a port in the range 8080-9999
-
-#### 3. No POS Connection
-
-**Symptom:**
-```
-❌ No POS terminals connected
-```
-
-**Solution:**
-1. Verify POS terminal network settings
-2. Ensure correct IP address and port from kiosk startup message
-3. Check local network connectivity:
-   ```bash
-   ping <kiosk-ip>
-   ```
-4. Verify firewall settings allow traffic on the port
-5. Test port accessibility:
-   ```bash
-   telnet <kiosk-ip> 8080
-   ```
-
-#### 4. Signature Validation Failed
-
-**Error:**
-```
-🔒 Security validation failed: Invalid signature
-```
-
-**Solution:**
-- Verify shared secret key matches on both sides: `POS-KIOSK-SECRET-KEY-2024`
-- Check message format integrity (JSON must be valid)
-- Ensure proper JSON encoding (UTF-8)
-- Verify payload is sorted by keys before signing
-
-#### 5. Invalid JSON Format
-
-**Error:**
-```
-❌ JSON decode error: [error message]
-```
-
-**Solution:**
-- Ensure messages are valid JSON
-- Check for proper quote escaping
-- Verify newline at end of message (`\n`)
-- Use JSON validators to check message format
-
-### Debugging with Logs
-
-**Capture detailed output to a file:**
 ```bash
 python3 kiosk.py 2>&1 | tee kiosk.log
-```
-
-**This creates a `kiosk.log` file with:**
-- 🔗 Connection events
-- 📨 Message exchanges
-- 🔐 Security validations
-- 💳 Payment processing status
-- ❌ Error conditions
-
-**Analyze the log file:**
-```bash
-# View the log
-cat kiosk.log
 
 # Search for errors
 grep "❌" kiosk.log
@@ -505,33 +294,11 @@ grep "❌" kiosk.log
 grep "🔐" kiosk.log
 ```
 
-### Performance Testing
+---
 
-For production environments, consider testing:
+## Example POS Test Client
 
-1. **Multiple concurrent POS connections:**
-   - Start 5-10 simulated POS terminals
-   - Send payment requests from each
-   - Monitor memory usage and response time
-
-2. **High-frequency payment requests:**
-   - Send 100+ payment requests rapidly
-   - Verify all are processed correctly
-   - Check for dropped or duplicate messages
-
-3. **Network interruption handling:**
-   - Simulate POS disconnections
-   - Verify graceful cleanup
-   - Check connection recovery
-
-4. **Memory usage under load:**
-   - Run for extended period with continuous traffic
-   - Monitor nonce storage size
-   - Verify periodic cleanup is working
-
-### Example Python Test Client
-
-For testing purposes, here's a minimal POS client example:
+This minimal Python client simulates a POS terminal. It works for **all deployment scenarios** — just change the `host` parameter:
 
 ```python
 import socket
@@ -541,47 +308,123 @@ import hashlib
 import uuid
 from datetime import datetime
 
-def create_test_response(txn_id):
-    """Create a test acknowledgment response"""
-    secret = "POS-KIOSK-SECRET-KEY-2024"
+# Configuration
+KIOSK_HOST = "127.0.0.1"   # Same device
+# KIOSK_HOST = "192.168.1.100"  # LAN
+# KIOSK_HOST = "pos.merchant.com"  # Internet
+KIOSK_PORT = 8080
+SECRET = "POS-KIOSK-SECRET-KEY-2024"  # Replace in production
 
-    payload = {
-        "type": "ack",
-        "txn_id": txn_id,
-        "status": "processing",
-        "timestamp": str(int(datetime.now().timestamp() * 1000)),
-        "nonce": str(uuid.uuid4())
-    }
-
-    # Create signature
+def sign(payload: dict) -> str:
+    """Create HMAC-SHA256 signature over sorted payload."""
     json_str = json.dumps(payload, sort_keys=True, separators=(',', ':'))
-    signature = hmac.new(
-        secret.encode('utf-8'),
+    return hmac.new(
+        SECRET.encode('utf-8'),
         json_str.encode('utf-8'),
         hashlib.sha256
     ).hexdigest()
 
-    return {
-        "payload": payload,
-        "signature": signature
+def build_message(msg_type: str, txn_id: str, **extra) -> bytes:
+    """Build a signed message with newline frame delimiter."""
+    payload = {
+        "type": msg_type,
+        "txn_id": txn_id,
+        "timestamp": str(int(datetime.now().timestamp() * 1000)),
+        "nonce": str(uuid.uuid4()),
+        **extra
     }
+    message = {"payload": payload, "signature": sign(payload)}
+    return json.dumps(message).encode('utf-8') + b'\n'  # \n is the frame delimiter
 
-# Connect to kiosk
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-sock.connect(('192.168.1.100', 8080))
+def simulate_pos():
+    print(f"Connecting to Kiosk at {KIOSK_HOST}:{KIOSK_PORT}...")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((KIOSK_HOST, KIOSK_PORT))
+    reader = sock.makefile('r')
+    print("✅ Connected!")
 
-# Receive payment request
-data = sock.recv(4096)
-request = json.loads(data.decode('utf-8'))
-txn_id = request['payload']['txn_id']
+    while True:
+        print("Waiting for payment request from Kiosk...")
+        raw = reader.readline()  # reads until \n
+        if not raw:
+            print("Connection closed by Kiosk.")
+            break
 
-# Send acknowledgment
-response = create_test_response(txn_id)
-sock.send(json.dumps(response).encode('utf-8') + b'\n')
+        request = json.loads(raw)
+        payload = request.get('payload', {})
+        txn_id = payload.get('txn_id', '')
+        msg_type = payload.get('type', '')
+        print(f"📨 Received: {msg_type} | TXN: {txn_id}")
 
-sock.close()
+        if msg_type == 'transaction_request':
+            payment_mode = payload.get('payment_mode', '')
+            amount = payload.get('amount', 0)
+            print(f"   Amount: RM{amount:.2f}, Mode: {payment_mode}")
+
+            # Step 1: Send ACK
+            ack = build_message("ack", txn_id, status="processing")
+            sock.send(ack)
+            print("   → Sent ACK (processing)")
+
+            if payment_mode == 'ipp':
+                # Step 2a: Send IPP plans for selection
+                result = build_message("transaction_result", txn_id,
+                    status="ipp_plans",
+                    amount=amount,
+                    plans=[{
+                        "planId": "IPP_3M",
+                        "frequency": "Monthly",
+                        "totalInstallments": 3,
+                        "installmentDetails": [
+                            {"installmentNumber": 1, "date": "2024-02-15", "amount": round(amount/3, 2), "installmentFee": 1.50, "installmentFeePercentage": 1.5},
+                            {"installmentNumber": 2, "date": "2024-03-15", "amount": round(amount/3, 2), "installmentFee": 1.50, "installmentFeePercentage": 1.5},
+                            {"installmentNumber": 3, "date": "2024-04-15", "amount": round(amount/3, 2), "installmentFee": 1.50, "installmentFeePercentage": 1.5},
+                        ]
+                    }]
+                )
+                sock.send(result)
+                print("   → Sent IPP plans")
+            else:
+                # Step 2b: Simulate successful payment
+                result = build_message("transaction_result", txn_id,
+                    status="success",
+                    authorization_code="AUTH123",
+                    card_last4="4242"
+                )
+                sock.send(result)
+                print("   → Sent transaction result: success")
+
+        elif msg_type == 'ipp_plan_selection':
+            plan_id = payload.get('plan_id', '')
+            print(f"   Selected plan: {plan_id}")
+            # ACK the plan selection
+            ack = build_message("ack", txn_id, status="processing")
+            sock.send(ack)
+            # Send final success
+            result = build_message("transaction_result", txn_id,
+                status="success",
+                authorization_code="AUTH456",
+                plan_id=plan_id
+            )
+            sock.send(result)
+            print("   → Sent final IPP success")
+
+        elif msg_type == 'cancel_transaction':
+            ack = build_message("ack", txn_id, status="received")
+            sock.send(ack)
+            print("   → Sent cancel ACK")
+
+    sock.close()
+
+if __name__ == "__main__":
+    simulate_pos()
 ```
+
+> **Tip:** To test all three deployment scenarios, only change `KIOSK_HOST`:
+> - Same device: `"127.0.0.1"`
+> - LAN: `"192.168.1.100"` (use the IP shown by kiosk.py on startup)
+> - Internet: your Kiosk's public IP or hostname
 
 ---
 
-**Note:** For API specifications and integration architecture details, refer to `INTEGRATION.md`
+*For API specifications and integration architecture, refer to [INTEGRATION.md](INTEGRATION.md)*


### PR DESCRIPTION
## Summary

This PR addresses feedback on the POS-KIOSK integration documentation to make it universally usable across all deployment scenarios — whether the Kiosk and POS apps are on the **same device**, the **same LAN**, or connected over the **internet**.

The core TCP protocol is unchanged. Only the documentation, examples, and guidance have been improved.

---

## Changes

### `INTEGRATION.md` (full overhaul)
- **New section: "Same Device vs Different Device"** — explains that `127.0.0.1` is used for same-device, LAN IP for local network, and public IP/hostname for internet; the protocol is identical in all cases
- - **Explicit message framing documented** — newline-delimited JSON (`\n`) is now documented as the required frame delimiter (previously only visible in test code)
- - **New: Platform code examples** — working client snippets for Android (Kotlin), iOS/Swift, and Windows/C# — each with a comment showing how to switch between same-device, LAN, and internet targets
- - **New: Connection Lifecycle & Reconnection** — guidance on startup connect, keep-alive, exponential backoff retry, and mid-transaction disconnect handling
- - **Production security warnings** — shared secret must be replaced in production (minimum 32 chars, rotate periodically); nonce store must be Redis-backed for high-volume environments
- - **Android network security config** — `network_security_config.xml` example for cleartext TCP on API 28+
- - **iOS notes** — `NSLocalNetworkUsageDescription` and enterprise deployment context
- - **Improved network configuration table** — covers all three deployment scenarios with required steps for each
### `TESTING.md` (full overhaul)
- **New testing scenarios** — same-device (127.0.0.1), LAN, and internet testing explicitly documented
- - **Overhauled Python POS test client** — now handles all payment modes (card, bnpl, duitnow_qr, ipp, cancel), IPP plan response simulation, and correct newline frame delimiter
- - **Troubleshooting restructured as a table** — with NTP clock sync added for timestamp failures
- - **Expected output examples** — added for all test scenarios
### `README.md` (pos-kiosk-integration)
- Added universal deployment callout at the top
- - Added Quick Start table linking to the right doc for each integration path
---

## Testing

All changes are documentation and reference code only. Verified by reviewing rendered markdown and checking code snippet correctness manually.